### PR TITLE
Topic/minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.swp
+build
+*.ply
+*.sift
+blort_ros/bin/tracking.ini
+blort_ros/Resources/ply/*.jpg

--- a/blort/CMakeLists.txt
+++ b/blort/CMakeLists.txt
@@ -37,6 +37,7 @@ rosbuild_add_compile_flags(module_glwindow -DLINUX)
 target_link_libraries(module_glwindow GLU GL glut X11 rt)
 
 rosbuild_add_library(module_tomgine
+    src/TomGine/tgMathlib.cpp
     src/TomGine/tgVector3.cpp 
     src/TomGine/tgTimer.cpp 
     src/TomGine/tgTexture.cpp 

--- a/blort/CMakeLists.txt
+++ b/blort/CMakeLists.txt
@@ -7,7 +7,8 @@ include($ENV{ROS_ROOT}/core/rosbuild/rosbuild.cmake)
 #  Release        : w/o debug symbols, w/ optimization
 #  RelWithDebInfo : w/ debug symbols, w/ optimization
 #  MinSizeRel     : w/o debug symbols, w/ optimization, stripped binaries
-set(ROS_BUILD_TYPE Release)
+# set(ROS_BUILD_TYPE Release)
+set(ROS_BUILD_TYPE RelWithDebInfo)
 
 rosbuild_init()
 

--- a/blort/include/blort/TomGine/tgCamera.h
+++ b/blort/include/blort/TomGine/tgCamera.h
@@ -78,16 +78,16 @@ public:
 		float zFar;
 		
 		void print(){
-			printf("%u %u\n", width, height);
-			printf("%f %f\n", fx, fy);
-			printf("%f %f\n", cx, cy);
-			printf("%f %f %f\n", k1, k2, k3);
-			printf("%f %f\n", p1, p2);
-			printf("\n %f %f %f\n", rot.mat[0], rot.mat[1], rot.mat[2]);
+			printf("width = %u height = %u\n", width, height);
+			printf("fx = %f fy = %f\n", fx, fy);
+			printf("cx = %f cy = %f\n", cx, cy);
+			printf("k1 = %f k2 = %f k3 = %f\n", k1, k2, k3);
+			printf("p1 = %f p2 = %f\n", p1, p2);
+			printf("rot\n %f %f %f\n", rot.mat[0], rot.mat[1], rot.mat[2]);
 			printf(" %f %f %f\n", rot.mat[3], rot.mat[4], rot.mat[5]);
 			printf(" %f %f %f\n", rot.mat[6], rot.mat[7], rot.mat[8]);
-			printf("\n %f %f %f\n", pos.x, pos.y, pos.z);
-			printf("%f %f\n", zNear, zFar);
+			printf("pos\n %f %f %f\n", pos.x, pos.y, pos.z);
+			printf("zNear = %f zFar = %f\n", zNear, zFar);
 		}
 	};
 	

--- a/blort/include/blort/TomGine/tgMathlib.h
+++ b/blort/include/blort/TomGine/tgMathlib.h
@@ -22,6 +22,7 @@
 
 #include <math.h>
 #include <stdlib.h>
+#include <ostream>
 
 #ifndef PI
 #define PI 3.14159265358979323846f
@@ -846,6 +847,8 @@ struct mat4 {
 
     float mat[16];
 };
+
+std::ostream & operator<<(std::ostream & out, const mat3 & m);
 
 inline mat3::mat3(const mat4 &m) {
     mat[0] = m[0]; mat[3] = m[4]; mat[6] = m[8];

--- a/blort/include/blort/Tracker/ModelEntry.h
+++ b/blort/include/blort/Tracker/ModelEntry.h
@@ -10,31 +10,13 @@
 #define _MODEL_ENTRY_H_
 
 #include <blort/TomGine/tgMathlib.h>
+#include <blort/Tracker/TrackingStates.h>
 #include <blort/Tracker/TrackerModel.h>
 #include <blort/Tracker/Distribution.h>
 #include <blort/Tracker/Predictor.h>
 #include <blort/Tracker/Filter.h>
 
 namespace Tracking{
-
-enum quality_state{
-	ST_OK,
-	ST_OCCLUDED,
-	ST_LOST,
-	ST_LOCKED,
-};
-
-enum confidence_state{
-	ST_GOOD,
-	ST_FAIR,
-	ST_BAD,
-};
-
-enum movement_state{
-	ST_FAST,
-	ST_SLOW,
-	ST_STILL,
-};
 
 /** @brief class ModelEntry */
 class ModelEntry
@@ -115,10 +97,5 @@ public:
 };
 
 } // namespace Tracking
-
-/* ostream operators for states enum */
-std::ostream & operator<<(std::ostream & out, const Tracking::quality_state & st);
-std::ostream & operator<<(std::ostream & out, const Tracking::confidence_state & st);
-std::ostream & operator<<(std::ostream & out, const Tracking::movement_state & st);
 
 #endif

--- a/blort/include/blort/Tracker/ModelEntry.h
+++ b/blort/include/blort/Tracker/ModelEntry.h
@@ -116,4 +116,9 @@ public:
 
 } // namespace Tracking
 
+/* ostream operators for states enum */
+std::ostream & operator<<(std::ostream & out, const Tracking::quality_state & st);
+std::ostream & operator<<(std::ostream & out, const Tracking::confidence_state & st);
+std::ostream & operator<<(std::ostream & out, const Tracking::movement_state & st);
+
 #endif

--- a/blort/include/blort/Tracker/Resources.h
+++ b/blort/include/blort/Tracker/Resources.h
@@ -14,7 +14,7 @@
 #define FN_LEN 256
 #endif
 
-#define g_Resources Resources::GetInstance()
+#define g_Resources Tracking::Resources::GetInstance()
 
 namespace Tracking{
 

--- a/blort/include/blort/Tracker/TrackingStates.h
+++ b/blort/include/blort/Tracker/TrackingStates.h
@@ -1,0 +1,80 @@
+#ifndef _H_TRACKINGSTATES_H_
+#define _H_TRACKINGSTATES_H_
+
+#include <ostream>
+
+namespace Tracking{
+
+enum quality_state{
+    ST_OK,
+    ST_OCCLUDED,
+    ST_LOST,
+    ST_LOCKED,
+};
+
+enum confidence_state{
+    ST_GOOD,
+    ST_FAIR,
+    ST_BAD,
+};
+
+enum movement_state{
+    ST_FAST,
+    ST_SLOW,
+    ST_STILL,
+};
+
+/* ostream operators for states enum */
+inline std::ostream & operator<<(std::ostream & out, const Tracking::quality_state & st)
+{
+    switch(st)
+    {
+        case Tracking::ST_OK:
+            out << "OK"; break;
+        case Tracking::ST_OCCLUDED:
+            out << "OCCLUDED"; break;
+        case Tracking::ST_LOST:
+            out << "LOST"; break;
+        case Tracking::ST_LOCKED:
+            out << "LOCKED"; break;
+        default:
+            out << "UNIMPLEMENTED"; break;
+    }
+    return out;
+}
+
+inline std::ostream & operator<<(std::ostream & out, const Tracking::confidence_state & st)
+{
+    switch(st)
+    {
+        case Tracking::ST_GOOD:
+            out << "GOOD"; break;
+        case Tracking::ST_FAIR:
+            out << "FAIR"; break;
+        case Tracking::ST_BAD:
+            out << "BAD"; break;
+        default:
+            out << "UNIMPLEMENTED"; break;
+    }
+    return out;
+}
+
+inline std::ostream & operator<<(std::ostream & out, const Tracking::movement_state & st)
+{
+    switch(st)
+    {
+        case Tracking::ST_FAST:
+            out << "FAST"; break;
+        case Tracking::ST_SLOW:
+            out << "SLOW"; break;
+        case Tracking::ST_STILL:
+            out << "STILL"; break;
+        default:
+            out << "UNIMPLEMENTED"; break;
+    }
+    return out;
+}
+
+}
+
+#endif

--- a/blort/src/Recognizer3D/DetectSIFT.cc
+++ b/blort/src/Recognizer3D/DetectSIFT.cc
@@ -8,6 +8,7 @@
 #include <blort/Recognizer3D/DetectSIFT.hh>
 #include <blort/Recognizer3D/SDraw.hh>
 #include <string>
+#include <unistd.h>
 
 namespace P 
 {

--- a/blort/src/TomGine/tgMathlib.cpp
+++ b/blort/src/TomGine/tgMathlib.cpp
@@ -1,0 +1,8 @@
+#include <blort/TomGine/tgMathlib.h>
+
+std::ostream & operator<<(std::ostream & out, const mat3 & m)
+{
+    out << m.mat[0] << " " << m.mat[1] << " " << m.mat[2] << std::endl;
+    out << m.mat[3] << " " << m.mat[4] << " " << m.mat[5] << std::endl;
+    out << m.mat[6] << " " << m.mat[7] << " " << m.mat[8] << std::endl;
+}

--- a/blort/src/Tracker/ModelEntry.cpp
+++ b/blort/src/Tracker/ModelEntry.cpp
@@ -1,8 +1,57 @@
 #include <blort/Tracker/ModelEntry.h>
 #include <ros/console.h>
 
-
 using namespace Tracking;
+
+std::ostream & operator<<(std::ostream & out, const quality_state & st)
+{
+    switch(st)
+    {
+        case ST_OK:
+            out << "OK"; break;
+        case ST_OCCLUDED:
+            out << "OCCLUDED"; break;
+        case ST_LOST:
+            out << "LOST"; break;
+        case ST_LOCKED:
+            out << "LOCKED"; break;
+        default:
+            out << "UNIMPLEMENTED"; break;
+    }
+    return out;
+}
+
+std::ostream & operator<<(std::ostream & out, const confidence_state & st)
+{
+    switch(st)
+    {
+        case ST_GOOD:
+            out << "GOOD"; break;
+        case ST_FAIR:
+            out << "FAIR"; break;
+        case ST_BAD:
+            out << "BAD"; break;
+        default:
+            out << "UNIMPLEMENTED"; break;
+    }
+    return out;
+}
+
+std::ostream & operator<<(std::ostream & out, const movement_state & st)
+{
+    switch(st)
+    {
+        case ST_FAST:
+            out << "FAST"; break;
+        case ST_SLOW:
+            out << "SLOW"; break;
+        case ST_STILL:
+            out << "STILL"; break;
+        default:
+            out << "UNIMPLEMENTED"; break;
+    }
+    return out;
+}
 
 /** @brief class ModelEntry */
 ModelEntry::ModelEntry()
@@ -15,7 +64,7 @@ ModelEntry::ModelEntry()
 	num_convergence = 0;
   st_quality = ST_OK; //2012-11-28: added by Jordi
 	mask = 0;
-  ROS_WARN_STREAM("ModelEntry(): st_quality = " << st_quality );
+  ROS_WARN_STREAM("(" << label << ") ModelEntry(): st_quality = " << st_quality );
 }
 
 ModelEntry::ModelEntry(const TomGine::tgModel& m)
@@ -131,7 +180,7 @@ void ModelEntry::evaluate_states(const Particle &variation, unsigned rec,
 	else
 		st_movement = ST_FAST;
 
-  ROS_INFO_STREAM("ModeEntry: evaluate_states: c_edge = " << c_edge << "  c_lost = " << c_lost << "  c_th_lost = " << c_th_lost);
+  ROS_INFO_STREAM("(" << label << ") ModeEntry: evaluate_states: c_edge = " << c_edge << "  c_th = " << c_th << " c_lost = " << c_lost << "  c_th_lost = " << c_th_lost);
   ROS_INFO_STREAM("                            st_movement = " << st_movement << "  st_quality = " << st_quality);
 	
 	//// Lost detection
@@ -169,6 +218,6 @@ void ModelEntry::evaluate_states(const Particle &variation, unsigned rec,
 		st_quality = ST_OK;
 	}
 
-  ROS_INFO_STREAM("ModelEntry::evaluate_states has set st_confidence = " << st_confidence << "  st_quality = " << st_quality);
+  ROS_INFO_STREAM("(" << label << ") ModelEntry::evaluate_states has set st_confidence = " << st_confidence << "  st_quality = " << st_quality);
 	
 }

--- a/blort/src/Tracker/ModelEntry.cpp
+++ b/blort/src/Tracker/ModelEntry.cpp
@@ -3,56 +3,6 @@
 
 using namespace Tracking;
 
-std::ostream & operator<<(std::ostream & out, const quality_state & st)
-{
-    switch(st)
-    {
-        case ST_OK:
-            out << "OK"; break;
-        case ST_OCCLUDED:
-            out << "OCCLUDED"; break;
-        case ST_LOST:
-            out << "LOST"; break;
-        case ST_LOCKED:
-            out << "LOCKED"; break;
-        default:
-            out << "UNIMPLEMENTED"; break;
-    }
-    return out;
-}
-
-std::ostream & operator<<(std::ostream & out, const confidence_state & st)
-{
-    switch(st)
-    {
-        case ST_GOOD:
-            out << "GOOD"; break;
-        case ST_FAIR:
-            out << "FAIR"; break;
-        case ST_BAD:
-            out << "BAD"; break;
-        default:
-            out << "UNIMPLEMENTED"; break;
-    }
-    return out;
-}
-
-std::ostream & operator<<(std::ostream & out, const movement_state & st)
-{
-    switch(st)
-    {
-        case ST_FAST:
-            out << "FAST"; break;
-        case ST_SLOW:
-            out << "SLOW"; break;
-        case ST_STILL:
-            out << "STILL"; break;
-        default:
-            out << "UNIMPLEMENTED"; break;
-    }
-    return out;
-}
-
 /** @brief class ModelEntry */
 ModelEntry::ModelEntry()
 : m_lpf_a(0.7f), m_lpf_t(0.7f), m_lpf_cs(0.2f), m_lpf_cl(0.99f)

--- a/blort_ros/CMakeLists.txt
+++ b/blort_ros/CMakeLists.txt
@@ -7,7 +7,7 @@ include($ENV{ROS_ROOT}/core/rosbuild/rosbuild.cmake)
 #  Release        : w/o debug symbols, w/ optimization
 #  RelWithDebInfo : w/ debug symbols, w/ optimization
 #  MinSizeRel     : w/o debug symbols, w/ optimization, stripped binaries
-#set(ROS_BUILD_TYPE RelWithDebInfo)
+set(ROS_BUILD_TYPE RelWithDebInfo)
 
 rosbuild_init()
 

--- a/blort_ros/launch/learnsifts.launch
+++ b/blort_ros/launch/learnsifts.launch
@@ -1,14 +1,10 @@
 <launch>
+    <arg name="info" default="/stereo/left/camera_info" />
+    <arg name="image" default="/stereo/left/image" />
 
     <node pkg="blort_ros" type="learnsifts" name="blort_learnsifts" args="$(find blort_ros)" output="screen">
-<!--
-        <remap from="/blort_camera" to="/gscam/camera_info" />
-        <remap from="/blort_image" to="/gscam/image_raw" /> 
-        <remap from="/blort_camera" to="/disparity_segment/camera_info" />
-        <remap from="/blort_image" to="/disparity_segment/image_rect_masked" /> 
--->
-        <remap from="/blort_camera" to="/stereo/left/camera_info" />
-        <remap from="/blort_image" to="/stereo/left/image" /> 
+        <remap from="/blort_camera" to="$(arg info)" />
+        <remap from="/blort_image" to="$(arg image)" />
     </node>
 
 </launch>

--- a/blort_ros/launch/tracking.launch
+++ b/blort_ros/launch/tracking.launch
@@ -1,27 +1,18 @@
 <launch>
+    <arg name="image" default="/stereo/left/image" />
+    <arg name="info"  default="/stereo/left/camera_info" />
 
     <!-- Tracker node -->
     <node pkg="blort_ros" type="gltracker_node" name="blort_tracker" args="$(find blort_ros)" output="screen">
         <param name="launch_mode" value="tracking" />
-        <!-- WEBCAM -->
-<!--        
-        <remap from="/blort_camera_info" to="/gscam/camera_info" />
-        <remap from="/blort_image" to="/gscam/image_raw" />
--->
-        <!-- STEREO CAMERA FROM TUTORIALS -->        
-        <remap from="/detector_camera_info" to="/stereo/left/camera_info" />
-        <remap from="/detector_image" to="/stereo/left/image" />
-        <remap from="/tracker_image" to="/stereo/left/image" />           
+        <remap from="/detector_camera_info" to="$(arg info)" />
+        <remap from="/detector_image" to="$(arg image)" />
+        <remap from="/tracker_image" to="$(arg image)" />           
     </node>
     
     <!-- Detector node -->
     <node pkg="blort_ros" type="gldetector_node" name="blort_detector" args="$(find blort_ros)" output="screen">
-        <!-- WEBCAM -->
-<!--
-        <remap from="/blort_camera_info" to="/gscam/camera_info" />
--->
-        <!-- STEREO CAMERA FROM TUTORIALS -->
-        <remap from="/blort_camera_info" to="/stereo/left/camera_info" />
+        <remap from="/blort_camera_info" to="$(arg info)" />
     </node>
 
 </launch>

--- a/blort_ros/src/gltracker.h
+++ b/blort_ros/src/gltracker.h
@@ -146,7 +146,9 @@ namespace blort_ros
 
         void setVisualizeObjPose(bool enable){ visualize_obj_pose = enable; }
 
-        void setPublisMode(TrackerPublishMode mode){ publish_mode = mode; }
+        void setPublishMode(TrackerPublishMode mode){ publish_mode = mode; }
+
+        TrackerPublishMode getPublishMode() { return (TrackerPublishMode)publish_mode; }
 
         void resetParticleFilter();
 

--- a/blort_ros/src/nodes/tracker_node.cpp
+++ b/blort_ros/src/nodes/tracker_node.cpp
@@ -349,7 +349,7 @@ private:
                 } else {
                     parent_->tracker->reset();
                 }
-                parent_->tracker->setPublisMode(blort_ros::TRACKER_PUBLISH_GOOD);
+                parent_->tracker->setPublishMode(blort_ros::TRACKER_PUBLISH_GOOD);
                 parent_->tracker->setVisualizeObjPose(true);
                 blort_ros::SetCameraInfo camera_info;
                 camera_info.request.CameraInfo = *lastCameraInfo;

--- a/blort_ros/src/nodes/tracker_node.cpp
+++ b/blort_ros/src/nodes/tracker_node.cpp
@@ -155,7 +155,8 @@ public:
                 tracker->process(cv_tracker_ptr->image);
 
                 confidences_pub.publish(tracker->getConfidences());
-                if(tracker->getConfidence() == blort_ros::TRACKER_CONF_GOOD)
+                if(tracker->getConfidence() == blort_ros::TRACKER_CONF_GOOD ||
+                    (tracker->getConfidence() == blort_ros::TRACKER_CONF_FAIR && tracker->getPublishMode() == blort_ros::TRACKER_PUBLISH_ALL) )
                 {
                     geometry_msgs::Pose target_pose = pal_blort::blortPosesToRosPose(tracker->getCameraReferencePose(),
                                                                                      tracker->getDetections()[0]);


### PR DESCRIPTION
Hi,

This pull request brings in some minor fixes/improvements to perception_blort, mostly:
- Change default build from Release to RelWithDebInfo
- Add a few ostream operators and improve others
- Actually publish all positions if the option is activated
- Rename PublisMode to PublishMode
- Fix compilation on ubuntu 13.04 (or, more likely, gcc >= 4.7)
- Change Pose publication to PoseStamped
- Allow to remap the image topic and camera_info topic in learnsifts.launch and tracking.launch
