### PR TITLE
Topic/multiple objects

### DIFF
--- a/blort/include/blort/Recognizer3D/Recognizer3D.h
+++ b/blort/include/blort/Recognizer3D/Recognizer3D.h
@@ -64,7 +64,7 @@ public:
 	*   @param pose returned pose of the object (if found)
 	*   @param conf returned confidence of pose of the object
 	*   @return true if object found, false if not */
-	bool recognize(IplImage* tFrame, TomGine::tgPose& pose, float &conf);
+	bool recognize(IplImage* tFrame, std::vector< boost::shared_ptr<TomGine::tgPose> > & poses, std::vector<float> & confs);
 	
 	/** @brief add sift features to sift model of an object
 	*   @param tFrame image/pixel map to search for new sift features
@@ -93,7 +93,6 @@ public:
 	void getLastSifts(std::vector<Siftex> &sl){ sl = m_lastsiftexlist; }
 	
         //BENCE
-        unsigned int getCodeBookSize();
         cv::Mat getImage(){ return display_image; }
         void setDoUndistort(bool enable){ do_undistort = enable; }
 
@@ -107,10 +106,14 @@ private:
 	Recognizer3D();
 	
 	P::DetectGPUSIFT sift;
+    /* Used to load model in tracking, only one needed */
 	P::ModelObject3D m_sift_model_learner;
-	P::ODetect3D m_detect;
-	P::Object3D m_sift_model;
+    /* Use to perform detection, one should do it */
+    P::ODetect3D m_detect;
+    /* Store the model, need one per object */
+	std::vector< boost::shared_ptr<P::Object3D> > m_sift_models;
 	
+    /* Store all sifts in the image, shared among the objects */
 	P::Array<P::KeypointDescriptor*> m_image_keys;
 	
 	std::vector<Siftex> m_lastsiftexlist;

--- a/blort/include/blort/Recognizer3D/Recognizer3D.h
+++ b/blort/include/blort/Recognizer3D/Recognizer3D.h
@@ -52,7 +52,7 @@ public:
         *   @param prefix to be added to every file path
         *   @param display display sifts and found object in a window */
         Recognizer3D(const CameraParameter& camParam, std::string config_root = "",
-                     bool display = false);
+                     bool display = false, bool training = false);
 	~Recognizer3D();
 	
 	void setCameraParameter(const blortRecognizer::CameraParameter& camParam);
@@ -65,17 +65,21 @@ public:
 	*   @param conf returned confidence of pose of the object
 	*   @return true if object found, false if not */
 	bool recognize(IplImage* tFrame, std::vector< boost::shared_ptr<TomGine::tgPose> > & poses, std::vector<float> & confs);
+
+    /** @brief Creates a model for the training phase */
+    void initTrainingModel();
+
 	
 	/** @brief add sift features to sift model of an object
 	*   @param tFrame image/pixel map to search for new sift features
 	*   @param model shape description of model using faces and vertices (see TomGine::tgModel)
 	*   @param pose pose of the model as seen in the image */
-        bool learnSifts(IplImage* tFrame, const TomGine::tgModel& model, const TomGine::tgPose& pose);
+    bool learnSifts(IplImage* tFrame, const TomGine::tgModel& model, const TomGine::tgPose& pose);
 	
 	/** @brief load a sift model
 	*   @param sift_file relative path and name to sift file (i.e.: "../Resources/sift/TeaBox.sift")
 	*   @return success of loading the file */
-        bool loadModelFromFile(const std::string sift_file);
+    bool loadModelFromFile(const std::string sift_file);
 	
 	/** @brief save a sift model
 	*   @param sift_file relative path and name to sift file (i.e.: "../Resources/sift/TeaBox.sift")

--- a/blort/include/blort/Recognizer3D/Recognizer3D.h
+++ b/blort/include/blort/Recognizer3D/Recognizer3D.h
@@ -66,6 +66,14 @@ public:
 	*   @return true if object found, false if not */
 	bool recognize(IplImage* tFrame, std::vector< boost::shared_ptr<TomGine::tgPose> > & poses, std::vector<float> & confs);
 
+	/** @brief recognizes a object by using the loaded sift model file
+	*   @param tFrame Image/Pixel map to search for the sift model
+	*   @param pose returned pose of the object (if found)
+	*   @param conf returned confidence of pose of the object
+    *   @param select objects in this vector will be recognized
+	*   @return true if object found, false if not */
+	bool recognize(IplImage* tFrame, std::vector< boost::shared_ptr<TomGine::tgPose> > & poses, std::vector<float> & confs, const std::map<size_t, bool> & select);
+
     /** @brief Creates a model for the training phase */
     void initTrainingModel();
 

--- a/blort/include/blort/Recognizer3D/Recognizer3D.h
+++ b/blort/include/blort/Recognizer3D/Recognizer3D.h
@@ -24,7 +24,7 @@
 
 namespace blortRecognizer{
 
-/** @brief intrinsic camera parameter 
+/** @brief intrinsic camera parameter
 *   lookup OpenCV Camera Calibration and 3D Reconstruction
 *   http://opencv.willowgarage.com/documentation/cpp/camera_calibration_and_3d_reconstruction.html */
 struct CameraParameter {
@@ -49,16 +49,17 @@ class Recognizer3D{
 public:
 	/** @brief Construction of Recognizer
 	*   @param camParam camera parameter for camera calibration
-        *   @param prefix to be added to every file path
-        *   @param display display sifts and found object in a window */
-        Recognizer3D(const CameraParameter& camParam, std::string config_root = "",
+	*   @param prefix to be added to every file path
+	*   @param display display sifts and found object in a window */
+	Recognizer3D(const CameraParameter& camParam, std::string config_root = "",
                      bool display = false, bool training = false);
+
 	~Recognizer3D();
-	
+
 	void setCameraParameter(const blortRecognizer::CameraParameter& camParam);
-	
+
 	void setGaussian(int kernel, float stdDeviation){ m_gauss_kernel = kernel; m_gauss_dev = stdDeviation; }
-	
+
 	/** @brief recognizes a object by using the loaded sift model file
 	*   @param tFrame Image/Pixel map to search for the sift model
 	*   @param pose returned pose of the object (if found)
@@ -74,81 +75,81 @@ public:
 	*   @return true if object found, false if not */
 	bool recognize(IplImage* tFrame, std::vector< boost::shared_ptr<TomGine::tgPose> > & poses, std::vector<float> & confs, const std::map<size_t, bool> & select);
 
-    /** @brief Creates a model for the training phase */
-    void initTrainingModel();
+	/** @brief Creates a model for the training phase */
+	void initTrainingModel();
 
-	
+
 	/** @brief add sift features to sift model of an object
 	*   @param tFrame image/pixel map to search for new sift features
 	*   @param model shape description of model using faces and vertices (see TomGine::tgModel)
 	*   @param pose pose of the model as seen in the image */
 	bool learnSifts(IplImage* tFrame, const TomGine::tgModel& model, const TomGine::tgPose& pose);
-	
+
 	/** @brief load a sift model
 	*   @param sift_file relative path and name to sift file (i.e.: "../Resources/sift/TeaBox.sift")
 	*   @return success of loading the file */
     bool loadModelFromFile(const std::string sift_file);
-	
+
 	/** @brief save a sift model
 	*   @param sift_file relative path and name to sift file (i.e.: "../Resources/sift/TeaBox.sift")
 	*   @return success of saving the file */
 	bool saveModelToFile(const char* sift_file);
-	
+
 	/** @brief get position and normal vector of sift features in model
 	*   @param pl 3D point list of sift features (relative to object)
 	*   @param nl 3D normal vector list of sift features (in object space) */
 	void getSifts(std::vector<Siftex>& sl){ sl = m_siftexlist; }
-	
+
 	/** @brief get position and normal vector of sift features in model detected in the last call of learnSifts()
 	*   @param pl 3D point list of sift features (relative to object)
 	*   @param nl 3D normal vector list of sift features (in object space) */
 	void getLastSifts(std::vector<Siftex> &sl){ sl = m_lastsiftexlist; }
-	
-        //BENCE
-        cv::Mat getImage(){ return display_image; }
-        void setDoUndistort(bool enable){ do_undistort = enable; }
 
-        static void Convert(P::PoseCv& p1, TomGine::tgPose& p2);
+	//BENCE
+	cv::Mat getImage(){ return display_image; }
+	void setDoUndistort(bool enable){ do_undistort = enable; }
 
-        void setNNThreshold(double nn_threshold);
-        void setRansacNPointsToMatch(unsigned int n);
-        cv::Mat getDebugImage(){ return debug_image; }
+	static void Convert(P::PoseCv& p1, TomGine::tgPose& p2);
+
+	void setNNThreshold(double nn_threshold);
+	void setRansacNPointsToMatch(unsigned int n);
+	cv::Mat getDebugImage(){ return debug_image; }
 
 private:
 	Recognizer3D();
-	
+
 	P::DetectGPUSIFT sift;
-    /* Used to load model in tracking, only one needed */
+	/* Used to load model in tracking, only one needed */
 	P::ModelObject3D m_sift_model_learner;
-    /* Use to perform detection, one should do it */
-    P::ODetect3D m_detect;
-    /* Store the model, need one per object */
+	/* Use to perform detection, one should do it */
+	P::ODetect3D m_detect;
+	/* Store the model, need one per object */
 	std::vector< boost::shared_ptr<P::Object3D> > m_sift_models;
-	
-    /* Store all sifts in the image, shared among the objects */
+
+	/* Store all sifts in the image, shared among the objects */
 	P::Array<P::KeypointDescriptor*> m_image_keys;
-	
+
 	std::vector<Siftex> m_lastsiftexlist;
 	std::vector<Siftex> m_siftexlist;
-	
+
 	CvMat *pIntrinsicDistort;
 	CvMat *pDistortion;
 	CvMat *C;
 	CvMat *pMapX, *pMapY;
 	CameraParameter m_cp;
-	
+
 	bool m_model_loaded;
 	bool m_display;
-	
+
 	int m_gauss_kernel;
 	float m_gauss_dev;
 
-        //BENCE
-        cv::Mat display_image;
-        cv::Mat debug_image; // usually empty
-        bool do_undistort;
-        std::string config_root;
-        //cv::Ptr<pal_blort::CvDetect3D> cv_detect;
+	//BENCE
+	cv::Mat display_image;
+	cv::Mat debug_image; // usually empty
+	bool do_undistort;
+	std::string config_root;
+	//cv::Ptr<pal_blort::CvDetect3D> cv_detect;
 };
 
 }

--- a/blort/include/blort/Recognizer3D/Recognizer3D.h
+++ b/blort/include/blort/Recognizer3D/Recognizer3D.h
@@ -82,7 +82,7 @@ public:
 	*   @param tFrame image/pixel map to search for new sift features
 	*   @param model shape description of model using faces and vertices (see TomGine::tgModel)
 	*   @param pose pose of the model as seen in the image */
-    bool learnSifts(IplImage* tFrame, const TomGine::tgModel& model, const TomGine::tgPose& pose);
+	bool learnSifts(IplImage* tFrame, const TomGine::tgModel& model, const TomGine::tgPose& pose);
 	
 	/** @brief load a sift model
 	*   @param sift_file relative path and name to sift file (i.e.: "../Resources/sift/TeaBox.sift")

--- a/blort/include/blort/ThreadObject/RecognizerThread.h
+++ b/blort/include/blort/ThreadObject/RecognizerThread.h
@@ -26,11 +26,11 @@ private:
 	CMutexClass m_running;
 	
 	bool m_quit;
-	float m_conf;
+	std::vector<float> m_confs;
 	std::string m_sift_file;
 	blortRecognizer::CameraParameter m_params;
-	TomGine::tgPose m_pose;	
-	TomGine::tgModel m_model;
+	std::vector< boost::shared_ptr<TomGine::tgPose> > m_poses;	
+	std::vector< boost::shared_ptr<TomGine::tgModel> > m_models;
 	IplImage* m_image;
 	std::vector<blortRecognizer::Siftex> m_lastsiftexlist;
 	std::vector<blortRecognizer::Siftex> m_siftexlist;
@@ -43,7 +43,7 @@ public:
         CRecognizerThread(const blortRecognizer::CameraParameter& params, std::string config_root="");
 	~CRecognizerThread();
 	
-	void Recognize(IplImage* image, TomGine::tgPose& pose, float& conf);
+	void Recognize(IplImage* image, std::vector< boost::shared_ptr<TomGine::tgPose> > & poses, std::vector<float> & confs);
 	
 	void LearnSifts(IplImage* image,  TomGine::tgModel &model, TomGine::tgPose& pose);
 	

--- a/blort/include/blort/Tracker/TextureTracker.h
+++ b/blort/include/blort/Tracker/TextureTracker.h
@@ -63,6 +63,7 @@ namespace Tracking{
 	virtual void image_processing(unsigned char* image, int model_id, const TomGine::tgPose &p, GLenum format=GL_BGR);
 	
 	virtual bool track();
+    bool track(const std::vector<bool> & tracking_objects);
 	bool track(ModelEntry *modelEntry);
 	virtual bool track(int id);
 	

--- a/blort/include/blort/Tracker/utilities.hpp
+++ b/blort/include/blort/Tracker/utilities.hpp
@@ -301,6 +301,7 @@ void GetTrackingParameter( Tracking::Tracker::Parameter& params, const char* ini
     params.c_mv_slow = iniCDF.GetFloat("SlowMovementThreshold", "Movement");
 }
 
+/*FIXME Left temporally for backward compatiblity */
 void GetPlySiftFilenames(const char* ini_file, std::string &ply_file, std::string &sift_file, std::string &model_name)
 {
     CDataFile iniCDF;
@@ -319,6 +320,46 @@ void GetPlySiftFilenames(const char* ini_file, std::string &ply_file, std::strin
     model_name = iniCDF.GetString("Model", "Files");
     model_name = model_name.substr(0, model_name.find("."));
 
+}
+
+void GetPlySiftFilenames(const char* ini_file, std::vector<std::string> & ply_files, std::vector<std::string> & sift_files, std::vector<std::string> & model_names)
+{
+    CDataFile iniCDF;
+
+    if(!iniCDF.Load(ini_file)){
+        char errmsg[128];
+        sprintf(errmsg, "[utilities::GetTrackingParameter] Can not open tracking_ini file '%s'", ini_file);
+        throw std::runtime_error(errmsg);
+    }
+
+    ply_files.resize(0);
+    sift_files.resize(0);
+    model_names.resize(0);
+
+    {
+        std::string resource_path = iniCDF.GetString("ModelPath", "ResourcePath");
+        std::stringstream ss;
+        ss << iniCDF.GetString("Model", "Files");
+        while(ss.good())
+        {
+            std::string ply_file;
+            ss >> ply_file;
+            ply_files.push_back(resource_path + ply_file);
+            ply_file = ply_file.substr(0, ply_file.find("."));
+            model_names.push_back(ply_file);
+        }
+    }
+    {
+        std::string resource_path = iniCDF.GetString("SiftPath", "ResourcePath");
+        std::stringstream ss;
+        ss << iniCDF.GetString("SiftModel", "Files");
+        while(ss.good())
+        {
+            std::string sift_file;
+            ss >> sift_file;
+            sift_files.push_back(resource_path + sift_file);
+        }
+    }
 }
 
 bool InputControl(Tracking::Tracker* tracker, blortGLWindow::Event& event, std::string config_root =""){

--- a/blort/include/blort/Tracker/utilities.hpp
+++ b/blort/include/blort/Tracker/utilities.hpp
@@ -301,27 +301,6 @@ void GetTrackingParameter( Tracking::Tracker::Parameter& params, const char* ini
     params.c_mv_slow = iniCDF.GetFloat("SlowMovementThreshold", "Movement");
 }
 
-/*FIXME Left temporally for backward compatiblity */
-void GetPlySiftFilenames(const char* ini_file, std::string &ply_file, std::string &sift_file, std::string &model_name)
-{
-    CDataFile iniCDF;
-
-    if(!iniCDF.Load(ini_file)){
-        char errmsg[128];
-        sprintf(errmsg, "[utilities::GetTrackingParameter] Can not open tracking_ini file '%s'", ini_file);
-        throw std::runtime_error(errmsg);
-    }
-
-    ply_file = iniCDF.GetString("ModelPath", "ResourcePath");
-    ply_file.append(iniCDF.GetString("Model", "Files"));
-    sift_file = iniCDF.GetString("SiftPath", "ResourcePath");
-    sift_file.append(iniCDF.GetString("SiftModel", "Files"));
-
-    model_name = iniCDF.GetString("Model", "Files");
-    model_name = model_name.substr(0, model_name.find("."));
-
-}
-
 void GetPlySiftFilenames(const char* ini_file, std::vector<std::string> & ply_files, std::vector<std::string> & sift_files, std::vector<std::string> & model_names)
 {
     CDataFile iniCDF;

--- a/blort/src/Recognizer3D/Recognizer3D.cpp
+++ b/blort/src/Recognizer3D/Recognizer3D.cpp
@@ -47,7 +47,7 @@ void Recognizer3D::Convert(P::PoseCv& p1, TomGine::tgPose& p2){
 }
 
 Recognizer3D::Recognizer3D(const blortRecognizer::CameraParameter& camParam,
-                           std::string config_root, bool display)
+                           std::string config_root, bool display, bool training)
 {
     do_undistort = true;
     this->config_root = config_root;
@@ -95,6 +95,10 @@ Recognizer3D::Recognizer3D(const blortRecognizer::CameraParameter& camParam,
     m_display = display;
 
     m_model_loaded = false;
+    if(training)
+    {
+        initTrainingModel();
+    }
 
     //    // create and initialize opencv-based 3D detector core
     //    cv_detect = cv::Ptr<pal_blort::CvDetect3D>(new pal_blort::CvDetect3D("FAST","SIFT","FlannBased"));
@@ -382,6 +386,12 @@ bool Recognizer3D::loadModelFromFile(const std::string sift_file)
     //EXPERIMENTAL
     //cv_detect->addCodeBook(m_sift_model);
     return true;
+}
+
+void Recognizer3D::initTrainingModel()
+{
+    ROS_INFO("[Recognizer3D::initTrainingModel() creating an empty model for training");
+    m_sift_models.push_back(boost::shared_ptr<P::Object3D>(new P::Object3D()));
 }
 
 bool Recognizer3D::saveModelToFile(const char* sift_file)

--- a/blort/src/ThreadObject/RecognizerThread.cpp
+++ b/blort/src/ThreadObject/RecognizerThread.cpp
@@ -51,8 +51,10 @@ void CRecognizerThread::LearnSifts(IplImage* image,  TomGine::tgModel &model, To
 {
 	m_mutex.Lock();
 		cvCopyImage(image, m_image);
-		m_poses.push_back(boost::shared_ptr<TomGine::tgPose>(&pose));
-		m_models.push_back(boost::shared_ptr<TomGine::tgModel>(&model));
+        m_poses.clear();
+        m_models.clear();
+		m_poses.push_back(boost::shared_ptr<TomGine::tgPose>(new TomGine::tgPose(pose)));
+		m_models.push_back(boost::shared_ptr<TomGine::tgModel>(new TomGine::tgModel(model)));
 		cmd = LEARN;
 	m_mutex.Unlock();
 	
@@ -115,7 +117,7 @@ BOOL CRecognizerThread::OnTask()
 	m_running.Lock();
 	
 	
-        blortRecognizer::Recognizer3D m_recognizer(m_params, config_root, true);
+        blortRecognizer::Recognizer3D m_recognizer(m_params, config_root, true, true);
         //m_recognizer.setDoUndistort(false);
 	
 	while(!m_quit)

--- a/blort/src/Tracker/TextureTracker.cpp
+++ b/blort/src/Tracker/TextureTracker.cpp
@@ -613,7 +613,7 @@ void TextureTracker::drawResult(float linewidth){
 	glClear(GL_DEPTH_BUFFER_BIT);
 	
 	for(unsigned i=0; i<m_modellist.size(); i++){
-        if(m_modellist[i]->st_quality != Tracking::ST_LOST)
+        //if(m_modellist[i]->st_quality != Tracking::ST_LOST)
         {
             drawModelEntry(m_modellist[i], linewidth);
         }

--- a/blort/src/Tracker/TextureTracker.cpp
+++ b/blort/src/Tracker/TextureTracker.cpp
@@ -649,7 +649,10 @@ void TextureTracker::drawResult(float linewidth){
 	glClear(GL_DEPTH_BUFFER_BIT);
 	
 	for(unsigned i=0; i<m_modellist.size(); i++){
-		drawModelEntry(m_modellist[i], linewidth);
+        if(m_modellist[i]->st_quality != Tracking::ST_LOST)
+        {
+            drawModelEntry(m_modellist[i], linewidth);
+        }
 	}
 	
 // 	for(int i=0; i<m_hypotheses.size(); i++){

--- a/blort/src/Tracker/TextureTracker.cpp
+++ b/blort/src/Tracker/TextureTracker.cpp
@@ -442,65 +442,29 @@ void TextureTracker::image_processing(unsigned char* image, int model_id, const 
 
 bool TextureTracker::track()
 {
+  std::vector<bool> tracking_objects(m_modellist.size(), true);
+  return track(tracking_objects);
+}
+
+bool TextureTracker::track(const std::vector<bool> & tracking_objects)
+{
   if(!m_tracker_initialized)
   {
     ROS_ERROR("[TextureTracker::track()] Error tracker not initialised!\n");
-		return false;
-	}
-	
-	// Track models
-	for(unsigned i=0; i<m_modellist.size(); i++){
-		track(m_modellist[i]);
-	}
-	
-        //BENCE: this part never runs
-	// Track hypothesis
-//	ModelEntryList::iterator m1 = m_hypotheses.begin();
-//	while(m1 < m_hypotheses.end()){
-//		track((*m1));
-//		if((*m1)->num_convergence++>params.hypotheses_trials){
-//			if((*m1)->past_confidences.size() < params.hypotheses_trials){
-//
-//				(*m1)->past_confidences.push_back((*m1)->distribution.getMaxC());
-//				m_modellist[(*m1)->hypothesis_id]->past_confidences.push_back(m_modellist[(*m1)->hypothesis_id]->distribution.getMaxC());
-//			}else{
-//
-//				// Evaluate mean confidence of hypothesis
-//				float c_hyp = 0.0;
-//				int s = (*m1)->past_confidences.size();
-//				for(int j=0; j<s; j++){
-//					c_hyp += (*m1)->past_confidences[j];
-//				}
-//				if(s>0)
-//					c_hyp = c_hyp / (float)s;
-//
-//				// Evaluate mean confidence of model, the hypothesis belongs to
-//				float c_model = 0.0;
-//				s = m_modellist[(*m1)->hypothesis_id]->past_confidences.size();
-//				for(int j=0; j<s; j++){
-//					c_model += m_modellist[(*m1)->hypothesis_id]->past_confidences[j];
-//				}
-//				if(s>0)
-//					c_model = c_model / (float)s;
-//
-//				// Compare confidence of model to the hypothesis
-//				if(c_model >= c_hyp){
-//					// if model is more confident, delete hypothesis
-//					delete(*m1);
-//					m_hypotheses.erase(m1);
-//				}else{
-//					// if hypothesis is more confident, delete model and replace modellist-entry with hypothesis
-//					delete(m_modellist[(*m1)->hypothesis_id]);
-//					(*m1)->id = (*m1)->hypothesis_id;
-//					m_modellist[(*m1)->hypothesis_id] = (*m1);
-//					m_hypotheses.erase(m1);
-//				}
-//			}
-//		}
-//		m1++;
-//	}
-	tgCheckError("TextureTracker::track()");
-	return true;
+    return false;
+  }
+
+  // Track models
+  for(unsigned i=0; i<m_modellist.size(); i++)
+  {
+      if(tracking_objects[i])
+      {
+        track(m_modellist[i]);
+      }
+  }
+
+  tgCheckError("TextureTracker::track()");
+  return true;
 }
 
 bool TextureTracker::track(ModelEntry *modelEntry)

--- a/blort/src/Tracker/Tracker.cpp
+++ b/blort/src/Tracker/Tracker.cpp
@@ -330,7 +330,7 @@ int Tracker::addModel(TomGine::tgModel& m, tgPose& p, std::string label, bool bf
     modelEntry->num_particles = params.num_particles;
     modelEntry->num_recursions = params.num_recursions;
     m_modellist.push_back(modelEntry);
-    
+
     return modelEntry->id;
 }
 
@@ -363,7 +363,7 @@ int Tracker::addModelFromFile(const char* filename, tgPose& p, std::string label
     modelEntry->num_particles = params.num_particles;
     modelEntry->num_recursions = params.num_recursions;
     m_modellist.push_back(modelEntry);
-    
+
     return modelEntry->id;
 }
 

--- a/blort_ros/bin/tracking.ini
+++ b/blort_ros/bin/tracking.ini
@@ -19,8 +19,8 @@ TexturePath = Resources/texture/
 ShaderPath = Tracker/shader/
 
 [Files]
-Model = Pringles.ply
-SiftModel = Pringles.sift
+Model = cupboardsimple.ply
+SiftModel = cupboardsimple.sift
 CamCal = cam.cal
 PoseCal = pose.cal 
 

--- a/blort_ros/bin/tracking.ini
+++ b/blort_ros/bin/tracking.ini
@@ -19,8 +19,8 @@ TexturePath = Resources/texture/
 ShaderPath = Tracker/shader/
 
 [Files]
-Model = cupboardsimple.ply
-SiftModel = cupboardsimple.sift
+Model = Pringles.ply
+SiftModel = Pringles.sift
 CamCal = cam.cal
 PoseCal = pose.cal 
 

--- a/blort_ros/msg/TrackerConfidences.msg
+++ b/blort_ros/msg/TrackerConfidences.msg
@@ -1,3 +1,4 @@
+std_msgs/UInt32 obj_id
 float32 edgeConf
 float32 confThreshold
 float32 lostConf

--- a/blort_ros/msg/TrackerConfidences.msg
+++ b/blort_ros/msg/TrackerConfidences.msg
@@ -1,4 +1,4 @@
-std_msgs/UInt32 obj_id
+std_msgs/String obj_name
 float32 edgeConf
 float32 confThreshold
 float32 lostConf

--- a/blort_ros/msg/TrackerResults.msg
+++ b/blort_ros/msg/TrackerResults.msg
@@ -1,0 +1,2 @@
+std_msgs/String obj_name
+geometry_msgs/PoseStamped pose

--- a/blort_ros/src/gldetector.cpp
+++ b/blort_ros/src/gldetector.cpp
@@ -88,8 +88,12 @@ bool GLDetector::recoveryWithLast(std::vector<size_t> & obj_ids, blort_ros::Reco
         recPoses.push_back(boost::shared_ptr<TomGine::tgPose>(new TomGine::tgPose()));
     }
     std::vector<float> confs(sift_files.size(), 0);
-    ROS_INFO("\n");
-    recognizer->recognize(image_, recPoses, confs);
+    std::map<size_t, bool> select;
+    for(size_t i = 0; i < obj_ids.size(); ++i)
+    {
+        select[obj_ids[i]] = true;
+    }
+    recognizer->recognize(image_, recPoses, confs, select);
 
     bool found_one = false;
     resp.object_founds.resize(obj_ids.size());

--- a/blort_ros/src/gldetector.h
+++ b/blort_ros/src/gldetector.h
@@ -66,8 +66,8 @@ namespace blort_ros
         boost::shared_ptr<blortRecognizer::Recognizer3D> recognizer; // recovery component
 
         //config files //FIXME
-        std::string model_name, sift_file; // name of the current model
-        std::string pose_cal;   // filename with the pose calibration values
+        std::vector<std::string> model_names, sift_files; // name of the current model
+        std::vector<std::string> pose_cals;   // filename with the pose calibration values
 
         // Initialise image
         IplImage *image_; // iplimage that used be the in former blort tracker module
@@ -81,12 +81,12 @@ namespace blort_ros
                    const std::string& config_root);
 
         /** @brief Method to run and handle recovery state. */
-        bool recovery(const cv::Mat& image,
+        bool recovery(size_t obj_id, const cv::Mat& image,
                       blort_ros::RecoveryCall::Response &resp);
 
         /** @brief Method to run on the previously stored image.
          *  @see recovery */
-        bool recoveryWithLast(blort_ros::RecoveryCall::Response &resp);
+        bool recoveryWithLast(size_t obj_id, blort_ros::RecoveryCall::Response &resp);
 
         /** @brief Control the tracker using a ROS reconfigure_gui node.
          *  @param reconfigure_gui messagetype */

--- a/blort_ros/src/gldetector.h
+++ b/blort_ros/src/gldetector.h
@@ -81,12 +81,12 @@ namespace blort_ros
                    const std::string& config_root);
 
         /** @brief Method to run and handle recovery state. */
-        bool recovery(size_t obj_id, const cv::Mat& image,
+        bool recovery(std::vector<size_t> & obj_ids, const cv::Mat& image,
                       blort_ros::RecoveryCall::Response &resp);
 
         /** @brief Method to run on the previously stored image.
          *  @see recovery */
-        bool recoveryWithLast(size_t obj_id, blort_ros::RecoveryCall::Response &resp);
+        bool recoveryWithLast(std::vector<size_t> & obj_ids, blort_ros::RecoveryCall::Response &resp);
 
         /** @brief Control the tracker using a ROS reconfigure_gui node.
          *  @param reconfigure_gui messagetype */

--- a/blort_ros/src/gltracker.cpp
+++ b/blort_ros/src/gltracker.cpp
@@ -144,6 +144,10 @@ void GLTracker::track()
     {
         for(size_t i = 0; i < trPoses.size(); ++i)
         {
+            if(current_modes[i] == TRACKER_RECOVERY_MODE)
+            {
+                continue;
+            }
             trPoses[i]->Activate();
             glBegin(GL_LINES);
             glColor3f(1.0f, 0.0f, 0.0f);
@@ -358,6 +362,18 @@ void GLTracker::reset()
     {
         switchToRecovery(i);
     }
+}
+
+void GLTracker::switchToTracking(size_t id)
+{
+    TrackerInterface::switchToTracking(id);
+    tracker.getModelEntry(model_ids[id])->st_quality = Tracking::ST_OK;
+}
+
+void GLTracker::switchToRecovery(size_t id)
+{
+    TrackerInterface::switchToRecovery(id);
+    tracker.getModelEntry(model_ids[id])->st_quality = Tracking::ST_LOST;
 }
 
 GLTracker::~GLTracker()

--- a/blort_ros/src/gltracker.cpp
+++ b/blort_ros/src/gltracker.cpp
@@ -314,7 +314,7 @@ void GLTracker::update()
     {
         //update confidences for output
         Tracking::ModelEntry* myModelEntry = tracker.getModelEntry(model_ids[i]);
-        tracker_confidences[i]->obj_id.data = i;
+        tracker_confidences[i]->obj_name.data = model_names_[i];
         tracker_confidences[i]->edgeConf = myModelEntry->c_edge;
         tracker_confidences[i]->confThreshold = myModelEntry->c_th;
         tracker_confidences[i]->lostConf = myModelEntry->c_lost;

--- a/blort_ros/src/gltracker.cpp
+++ b/blort_ros/src/gltracker.cpp
@@ -123,6 +123,7 @@ void GLTracker::resetParticleFilter(size_t obj_i)
 
 void GLTracker::track()
 {
+    boost::mutex::scoped_lock lock(models_mutex);
     *image = last_image;
 
     // Track object
@@ -190,6 +191,7 @@ void GLTracker::track()
 
 void GLTracker::resetWithPose(size_t id, const geometry_msgs::Pose& new_pose)
 {
+    boost::mutex::scoped_lock lock(models_mutex);
     ConvertCam2World(pal_blort::rosPose2TgPose(new_pose), cam_pose, *trPoses[id]);
     tracker.setModelInitialPose(model_ids[id], *trPoses[id]);
     //2012-11-28: commented by Jordi because the resetParticleFilter will reset the ModelEntry

--- a/blort_ros/src/gltracker.cpp
+++ b/blort_ros/src/gltracker.cpp
@@ -78,10 +78,8 @@ GLTracker::GLTracker(const sensor_msgs::CameraInfo camera_info,
     pose_cal = pal_blort::addRoot("bin/pose.cal", config_root);
     //FIXME: make these ROS parameters or eliminate them and use the content as parameters
     std::string tracking_ini(pal_blort::addRoot("bin/tracking.ini", config_root));
-    std::string ply_model;
 
-    GetPlySiftFilenames(tracking_ini.c_str(), ply_model, sift_file, model_name);
-    ply_model_ = ply_model;
+    GetPlySiftFilenames(tracking_ini.c_str(), ply_models_, sift_files_, model_names_);
     GetTrackingParameter(track_params, tracking_ini.c_str(), config_root);
 
     tgcam_params = TomGine::tgCamera::Parameter(camera_info);
@@ -93,27 +91,33 @@ GLTracker::GLTracker(const sensor_msgs::CameraInfo camera_info,
     trPose.t = vec3(0.0, 0.1, 0.0);
     trPose.Rotate(0.0f, 0.0f, 0.5f);
 
-    model_id = tracker.addModelFromFile(pal_blort::addRoot(ply_model, config_root).c_str(), trPose, model_name.c_str(), true);
+    for(size_t i = 0; i < ply_models_[i]; ++i)
+    {
+        model_ids.push_back(tracker.addModelFromFile(pal_blort::addRoot(ply_models_[i], config_root).c_str(), trPose, model_names_[i].c_str(), true));
+        trPoses.push_back(boost::shared_ptr(new TomGine::tgPose));
+        movements.push_back(Tracking::ST_SLOW);
+        qualities.push_back(Tracking::ST_LOST);
+        tracking_confidences.push_back(Tracking::ST_BAD);
+        current_modes.push_back(blort_ros::TRACKER_RECOVERY_MODE);
+        current_confs.push_back(blort_ros::TRACKER_CONF_LOST);
+        tracker_confidences.push_back(boost::shared_ptr(new TrackerConfidences)):
+    }
     tracker.setLockFlag(true);
 
     image = cvCreateImage( cvSize(tgcam_params.width, tgcam_params.height), 8, 3 );
-
-    movement = Tracking::ST_SLOW;
-    quality = Tracking::ST_LOST;
-    tracker_confidence = Tracking::ST_BAD;
 
     // define the constant cam_pose to be published
     fixed_cam_pose = pal_blort::tgPose2RosPose(cam_pose);
 }
 
 //2012-11-27: added by Jordi
-void GLTracker::resetParticleFilter()
+void GLTracker::resetParticleFilter(size_t obj_i)
 {
-  tracker.removeModel(model_id);  
-  model_id = tracker.addModelFromFile(pal_blort::addRoot(ply_model_, config_root_).c_str(), trPose, model_name.c_str(), true);
-  movement = Tracking::ST_SLOW;
-  quality  = Tracking::ST_LOST;
-  tracker_confidence = Tracking::ST_BAD;  
+  tracker.removeModel(model_ids[obj_i]);
+  model_ids[obj_i] = tracker.addModelFromFile(pal_blort::addRoot(ply_models_[obj_i], config_root_).c_str(), trPose, model_names_[obj_i].c_str(), true);
+  movements[obj_i] = Tracking::ST_SLOW;
+  qualities[obj_i]  = Tracking::ST_LOST;
+  tracker_confidences[obj_i] = Tracking::ST_BAD;
 }
 
 void GLTracker::track()
@@ -129,60 +133,69 @@ void GLTracker::track()
 
     tracker.drawImage(0);
     tracker.drawCoordinates();
-    tracker.getModelPose(model_id, trPose);
+    for(size_t i = 0; i < model_ids.size(); ++i)
+    {
+        tracker.getModelPose(model_ids[i], *trPoses[i]);
+    }
     tracker.drawResult(2.0f);
 
     // visualize current object pose if needed. moving this piece of code is troublesome,
     // has to stay right after drawImage(), because of OpenGL
     if( 1 || visualize_obj_pose)
     {
-        trPose.Activate();
-        glBegin(GL_LINES);
-        glColor3f(1.0f, 0.0f, 0.0f);
-        glVertex3f(0.0f, 0.0f, 0.0f);
-        glVertex3f(1.0f, 0.0f, 0.0f);
+        for(size_t i = 0; i < trPoses.size(); ++i)
+        {
+            trPoses[i].Activate();
+            glBegin(GL_LINES);
+            glColor3f(1.0f, 0.0f, 0.0f);
+            glVertex3f(0.0f, 0.0f, 0.0f);
+            glVertex3f(1.0f, 0.0f, 0.0f);
 
-        glColor3f(0.0f, 1.0f, 0.0f);
-        glVertex3f(0.0f, 0.0f, 0.0f);
-        glVertex3f(0.0f, 1.0f, 0.0f);
+            glColor3f(0.0f, 1.0f, 0.0f);
+            glVertex3f(0.0f, 0.0f, 0.0f);
+            glVertex3f(0.0f, 1.0f, 0.0f);
 
-        glColor3f(0.0f, 0.0f, 1.0f);
-        glVertex3f(0.0f, 0.0f, 0.0f);
-        glVertex3f(0.0f, 0.0f, 1.0f);
-        glEnd();
-        trPose.Deactivate();
+            glColor3f(0.0f, 0.0f, 1.0f);
+            glVertex3f(0.0f, 0.0f, 0.0f);
+            glVertex3f(0.0f, 0.0f, 1.0f);
+            glEnd();
+            trPoses[i].Deactivate();
+        }
     }
 
     update();
 
-    if(quality == Tracking::ST_LOCKED)
+    for(size_t i = 0; i < trPoses.size(); ++i)
     {
-        this->current_mode = blort_ros::TRACKER_LOCKED_MODE;
-    }
-    else if(quality == Tracking::ST_LOST)
-    {
-      ROS_INFO("GLTracker::track: switching tracker to RECOVERY_MODE because object LOST\n");
-      switchToRecovery();
-    }
+        if(qualities[i] == Tracking::ST_LOCKED)
+        {
+            this->current_modes[i] = blort_ros::TRACKER_LOCKED_MODE;
+        }
+        else if(qualities[i] == Tracking::ST_LOST)
+        {
+          ROS_INFO("GLTracker::track: switching tracker to RECOVERY_MODE because object LOST\n");
+          switchToRecovery(i);
+        }
 
-    if(tracker_confidence == Tracking::ST_GOOD && movement == Tracking::ST_STILL && quality != Tracking::ST_LOCKED)
-    {
-      ROS_DEBUG_STREAM("Tracker is really confident (edge conf: " << tracker_confidences.edgeConf <<
-                      " lost conf: " << tracker_confidences.lostConf << ". Sorry, no learning with this node.");
+        if(tracking_confidences[i] == Tracking::ST_GOOD && movements[i] == Tracking::ST_STILL && qualities[i] != Tracking::ST_LOCKED)
+        {
+          ROS_DEBUG_STREAM("Tracker is really confident (edge conf: " << tracker_confidences[i]->edgeConf <<
+                          " lost conf: " << tracker_confidences[i]->lostConf << ". Sorry, no learning with this node.");
+        }
     }
 }
 
-void GLTracker::resetWithPose(const geometry_msgs::Pose& new_pose)
+void GLTracker::resetWithPose(size_t id, const geometry_msgs::Pose& new_pose)
 {
-    ConvertCam2World(pal_blort::rosPose2TgPose(new_pose), cam_pose, trPose);
-    tracker.setModelInitialPose(model_id, trPose);
+    ConvertCam2World(pal_blort::rosPose2TgPose(new_pose), cam_pose, *trPoses[id]);
+    tracker.setModelInitialPose(model_ids[id], *trPoses[id]);
     //2012-11-28: commented by Jordi because the resetParticleFilter will reset the ModelEntry
     //tracker.resetUnlockLock(); // this does one run of the tracker to update the probabilities
 
     //2012-11-27: added by Jordi
-    resetParticleFilter();
+    resetParticleFilter(id);
 
-    switchToTracking();
+    switchToTracking(id);
 
     //2012-11-27: commented by Jordi
     //update();
@@ -243,32 +256,31 @@ void GLTracker::trackerControl(int code, int param)
     }
 }
 
-std::string GLTracker::getStatusString()
-{
-    std::stringstream ss;
-    ss << "GLTracker, mode: ";
-    if(current_mode == blort_ros::TRACKER_TRACKING_MODE)
-        ss << "tracking";
-    else
-        ss << "recovery";
-
-    ss << " with target named: " << model_name << std::endl;
-    return ss.str();
-}
-
 cv::Mat GLTracker::getImage()
 {
     cv::Mat tmp;
+    blort_ros::tracker_mode current_mode = current_modes[0];
+    if(current_mode == TRACKER_RECOVERY_MODE)
+    {
+        for(size_t i = 1; i < current_modes.size(); ++i)
+        {
+            if(current_modes[i] != TRACKER_RECOVERY_MODE)
+            {
+                current_mode = current_modes[i];
+                break;
+            }
+        }
+    }
     switch(current_mode)
     {
     case TRACKER_RECOVERY_MODE:
         return tmp.empty()?last_image.clone():tmp; // do we need a copy?
         break;
     case TRACKER_TRACKING_MODE:
-        return tracker.getImage().clone();
-        break;
     case TRACKER_LOCKED_MODE:
         return tracker.getImage().clone();
+        break;
+    default:
         break;
     }
     return tmp;
@@ -309,15 +321,15 @@ void GLTracker::update()
     tracker.getModelMovementState(model_id, movement);
     tracker.getModelQualityState(model_id, quality);
     ROS_INFO_STREAM("GLTracker::update: the tracked model has set quality to " << quality);
-    tracker.getModelConfidenceState(model_id, tracker_confidence);
+    tracker.getModelConfidenceState(model_id, tracking_confidence);
 
-    switch(tracker_confidence)
+    switch(tracking_confidence)
     {
     case Tracking::ST_GOOD:
         this->current_conf = blort_ros::TRACKER_CONF_GOOD;
         updatePoseResult();
         break;
-    case Tracking::ST_FAIR:      
+    case Tracking::ST_FAIR:
         this->current_conf = blort_ros::TRACKER_CONF_FAIR;
         if(publish_mode == TRACKER_PUBLISH_GOOD_AND_FAIR ||
            publish_mode == TRACKER_PUBLISH_ALL)
@@ -332,7 +344,7 @@ void GLTracker::update()
             updatePoseResult();
         break;
     default:
-        ROS_ERROR("Unknown confidence value: %d", tracker_confidence);
+        ROS_ERROR("Unknown confidence value: %d", tracking_confidence);
         break;
     }
 }

--- a/blort_ros/src/gltracker.cpp
+++ b/blort_ros/src/gltracker.cpp
@@ -226,8 +226,13 @@ void GLTracker::reconfigure(blort_ros::TrackerConfig config)
     }
 }
 
-void GLTracker::trackerControl(int code, int param)
+void GLTracker::trackerControl(uint8_t code, const std::vector<uint8_t> & params)
 {
+    int param = -1;
+    if(params.size())
+    {
+        param = params[0];
+    }
     switch(code)
     {
     case 0: //l

--- a/blort_ros/src/gltracker.cpp
+++ b/blort_ros/src/gltracker.cpp
@@ -349,7 +349,7 @@ void GLTracker::update()
         {
             //update confidences for output
             Tracking::ModelEntry* myModelEntry = tracker.getModelEntry(model_ids[i]);
-            tracker_confidences[i]->obj_name.data = objects_[i].name;
+            tracker_confidences[i]->obj_name.data = model_names_[i];
             tracker_confidences[i]->edgeConf = myModelEntry->c_edge;
             tracker_confidences[i]->confThreshold = myModelEntry->c_th;
             tracker_confidences[i]->lostConf = myModelEntry->c_lost;
@@ -360,7 +360,7 @@ void GLTracker::update()
             // although the implementation would allow it, at several places, lacks this at several other.
             tracker.getModelMovementState(model_ids[i], movements[i]);
             tracker.getModelQualityState(model_ids[i], qualities[i]);
-            ROS_INFO_STREAM("GLTracker::update: the tracked model for " << objects_[i].name << " has set quality to " << qualities[i]);
+            ROS_INFO_STREAM("GLTracker::update: the tracked model for " << model_names_[i] << " has set quality to " << qualities[i]);
             tracker.getModelConfidenceState(model_ids[i], tracking_confidences[i]);
 
             switch(tracking_confidences[i])

--- a/blort_ros/src/gltracker.cpp
+++ b/blort_ros/src/gltracker.cpp
@@ -362,12 +362,25 @@ void GLTracker::update()
     }
 }
 
-void GLTracker::reset()
+void GLTracker::reset(const std::vector<uint8_t> & params)
 {
-    ROS_INFO("GLTracker::reset: switching tracker to RECOVERY_MODE\n");
-    for(size_t i = 0; i < model_ids.size(); ++i)
+    ROS_INFO("GLTracker::reset: switching tracker to RECOVERY_MODE");
+    if(!params.size())
     {
-        switchToRecovery(i);
+        for(size_t i = 0; i < model_ids.size(); ++i)
+        {
+            switchToRecovery(i);
+        }
+    }
+    else
+    {
+        for(size_t i = 0; i < params.size(); ++i)
+        {
+            if(params[i] < model_ids.size())
+            {
+                switchToRecovery(params[i]);
+            }
+        }
     }
 }
 

--- a/blort_ros/src/gltracker.h
+++ b/blort_ros/src/gltracker.h
@@ -82,22 +82,23 @@ namespace blort_ros
         Tracking::TextureTracker tracker;   // tracking module
 
         //config files //FIXME
-        std::string config_root_, ply_model_;
-        std::string model_name, sift_file; // name of the current model
+        std::string config_root_;
+        std::vector<std::string> ply_models_;
+        std::vector<std::string> model_names_, sift_files_; // name of the current model
         std::string pose_cal;   // filename with the pose calibration values
 
         // Model for Tracker
-        TomGine::tgPose trPose; // current pose of the object used by the tracker module
-        int model_id;
-        Tracking::movement_state movement;
-        Tracking::quality_state quality;
-        Tracking::confidence_state tracker_confidence;
+        std::vector< boost::shared_ptr<TomGine::tgPose> > trPoses; // current pose of the object used by the tracker module
+        std::vector<int> model_ids;
+        std::vector<Tracking::movement_state> movements;
+        std::vector<Tracking::quality_state> qualities;
+        std::vector<Tracking::confidence_state> tracking_confidences;
 
         // Initialise image
         IplImage *image; // iplimage object used be the former blort tracker module
 
         // result variables
-        TrackerConfidences tracker_confidences;
+        std::vector< boost::shared_ptr<TrackerConfidences> > tracker_confidences;
         geometry_msgs::Pose fixed_cam_pose;
         std::vector<geometry_msgs::Pose> result;
         
@@ -141,16 +142,13 @@ namespace blort_ros
         /** @brief Get the rendered image for visualization. */
         cv::Mat getImage();
 
-        /** @brief Get a status string describing the current state of the tracker. */
-        std::string getStatusString();
-
         void setVisualizeObjPose(bool enable){ visualize_obj_pose = enable; }
 
         void setPublishMode(TrackerPublishMode mode){ publish_mode = mode; }
 
         TrackerPublishMode getPublishMode() { return (TrackerPublishMode)publish_mode; }
 
-        void resetParticleFilter();
+        void resetParticleFilter(size_t id);
 
         ~GLTracker();
 

--- a/blort_ros/src/gltracker.h
+++ b/blort_ros/src/gltracker.h
@@ -94,6 +94,9 @@ namespace blort_ros
         std::vector<Tracking::quality_state> qualities;
         std::vector<Tracking::confidence_state> tracking_confidences;
 
+        // Protection mutex for multi-threaded access to the model/poses
+        boost::mutex models_mutex;
+
         // Initialise image
         IplImage *image; // iplimage object used be the former blort tracker module
 
@@ -151,8 +154,6 @@ namespace blort_ros
 
         TrackerPublishMode getPublishMode() { return (TrackerPublishMode)publish_mode; }
 
-        void resetParticleFilter(size_t id);
-
         virtual void switchToTracking(size_t id);
 
         virtual void switchToRecovery(size_t id);
@@ -167,6 +168,8 @@ namespace blort_ros
         /** @brief Assemble pose result to be published based on class variables.
           * The result is put in the corresponding variable. */
         void updatePoseResult(size_t i);
+
+        void resetParticleFilter(size_t id);
     };
 }
 

--- a/blort_ros/src/gltracker.h
+++ b/blort_ros/src/gltracker.h
@@ -128,10 +128,10 @@ namespace blort_ros
          */
         void trackerControl(int code, int param = -1);
 
-        void resetWithPose(const geometry_msgs::Pose& new_pose);
+        void resetWithPose(size_t obj_id, const geometry_msgs::Pose& new_pose);
 
         /** @brief Get some statistics of the actual tracking state. */
-        TrackerConfidences getConfidences(){ return tracker_confidences; }
+        const std::vector< boost::shared_ptr<TrackerConfidences> > & getConfidences(){ return tracker_confidences; }
 
         /** @brief Get the results of the latest detections. */
         const std::vector<geometry_msgs::Pose>& getDetections(){ return result; }
@@ -159,7 +159,7 @@ namespace blort_ros
 
         /** @brief Assemble pose result to be published based on class variables.
           * The result is put in the corresponding variable. */
-        void updatePoseResult();
+        void updatePoseResult(size_t i);
     };
 }
 

--- a/blort_ros/src/gltracker.h
+++ b/blort_ros/src/gltracker.h
@@ -142,6 +142,9 @@ namespace blort_ros
         /** @brief Get the rendered image for visualization. */
         cv::Mat getImage();
 
+        /** @brief Return model names */
+        const std::vector<std::string> & getModelNames() { return model_names_; }
+
         void setVisualizeObjPose(bool enable){ visualize_obj_pose = enable; }
 
         void setPublishMode(TrackerPublishMode mode){ publish_mode = mode; }
@@ -149,6 +152,10 @@ namespace blort_ros
         TrackerPublishMode getPublishMode() { return (TrackerPublishMode)publish_mode; }
 
         void resetParticleFilter(size_t id);
+
+        virtual void switchToTracking(size_t id);
+
+        virtual void switchToRecovery(size_t id);
 
         ~GLTracker();
 

--- a/blort_ros/src/gltracker.h
+++ b/blort_ros/src/gltracker.h
@@ -119,7 +119,7 @@ namespace blort_ros
         /** @brief Method to run and handle tracking. */
         virtual void track();
 
-        void reset();
+        void reset(const std::vector<uint8_t> & params = std::vector<uint8_t>(0));
 
         /** @brief Control the tracker using a ROS reconfigure_gui node.
          *  @param Reconfigure_gui messagetype */

--- a/blort_ros/src/gltracker.h
+++ b/blort_ros/src/gltracker.h
@@ -93,6 +93,7 @@ namespace blort_ros
         std::vector<Tracking::movement_state> movements;
         std::vector<Tracking::quality_state> qualities;
         std::vector<Tracking::confidence_state> tracking_confidences;
+        std::vector<bool> tracking_objects;
 
         // Protection mutex for multi-threaded access to the model/poses
         boost::mutex models_mutex;
@@ -157,6 +158,8 @@ namespace blort_ros
         virtual void switchToTracking(size_t id);
 
         virtual void switchToRecovery(size_t id);
+
+        virtual void switchTracking(const std::vector<uint8_t> & params);
 
         ~GLTracker();
 

--- a/blort_ros/src/gltracker.h
+++ b/blort_ros/src/gltracker.h
@@ -129,7 +129,7 @@ namespace blort_ros
          *  @param code integer code associated with command, can be used with enums.
          *  @param param parameter of the command
          */
-        void trackerControl(int code, int param = -1);
+        void trackerControl(uint8_t code, const std::vector<uint8_t> & params);
 
         void resetWithPose(size_t obj_id, const geometry_msgs::Pose& new_pose);
 

--- a/blort_ros/src/nodes/detector_node.cpp
+++ b/blort_ros/src/nodes/detector_node.cpp
@@ -38,8 +38,7 @@ bool DetectorNode::recovery(blort_ros::RecoveryCall::Request &req,
             cv_bridge::CvImagePtr cv_ptr;
             try
             {
-                //cv_ptr = cv_bridge::toCvCopy(req.Image, sensor_msgs::image_encodings::BGR8);
-              cv_ptr = cv_bridge::toCvCopy(req.Image, req.Image.encoding);
+              cv_ptr = cv_bridge::toCvCopy(req.Image, sensor_msgs::image_encodings::BGR8);
               ROS_INFO_STREAM("\n\nENCODING = " << req.Image.encoding << "\n\n\n");
             }
             catch (cv_bridge::Exception& e)

--- a/blort_ros/src/nodes/detector_node.cpp
+++ b/blort_ros/src/nodes/detector_node.cpp
@@ -97,6 +97,7 @@ public:
         {
             ROS_INFO("Detector called the %u-th time.", ++counter);
             bool result;
+            resp.object_id = req.object_id;
             if(!req.Image.data.empty())
             {
                 cv_bridge::CvImagePtr cv_ptr;
@@ -111,10 +112,10 @@ public:
                     ROS_ERROR("cv_bridge exception: %s", e.what());
                     return false;
                 }
-                result = detector->recovery(cv_ptr->image, resp);
+                result = detector->recovery(req.object_id.data, cv_ptr->image, resp);
             } else {
                 ROS_INFO("Running detector on latest image.");
-                result = detector->recoveryWithLast(resp);
+                result = detector->recoveryWithLast(req.object_id.data, resp);
             }
             cv_bridge::CvImage out_msg;
             out_msg.header = req.Image.header;

--- a/blort_ros/src/nodes/detector_node.cpp
+++ b/blort_ros/src/nodes/detector_node.cpp
@@ -1,187 +1,111 @@
-/*
- * Software License Agreement (Modified BSD License)
- *
- *  Copyright (c) 2012, PAL Robotics, S.L.
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions
- *  are met:
- *
- *   * Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above
- *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials provided
- *     with the distribution.
- *   * Neither the name of PAL Robotics, S.L. nor the names of its
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *  POSSIBILITY OF SUCH DAMAGE. 
- *
- * @file detector_node.cpp
- * @author Bence Magyar
- * @date June 2012
- * @version 0.2
- * @brief Main file of BLORT detector node for ROS.
- */
+#include "detector_node.h"
 
-#include <ros/ros.h>
-#include <opencv2/core/core.hpp>
-#include <image_transport/image_transport.h>
-#include <cv_bridge/cv_bridge.h>
-#include <sensor_msgs/image_encodings.h>
-#include <dynamic_reconfigure/server.h>
-#include <blort_ros/DetectorConfig.h>
-#include <blort_ros/SetCameraInfo.h>
-#include "../gldetector.h"
-
-class DetectorNode
+DetectorNode::DetectorNode(std::string root)
+    : nh_("blort_detector"), it_(nh_), root_(root), detector(0)
 {
-private:
-    ros::NodeHandle nh_;
-    image_transport::ImageTransport it_;
-    image_transport::Publisher image_pub;
-    ros::Subscriber cam_info_sub;
-    const std::string root_;
-    ros::ServiceServer pose_service;
-    ros::ServiceServer cam_info_service;
-    std::auto_ptr<dynamic_reconfigure::Server<blort_ros::DetectorConfig> > server_;
-    dynamic_reconfigure::Server<blort_ros::DetectorConfig>::CallbackType f_;
-    blort_ros::GLDetector* detector;
-    unsigned int counter;
+    cam_info_sub = nh_.subscribe("/blort_camera_info", 1, &DetectorNode::cam_info_callback, this);
+    image_pub = it_.advertise("image_result", 1);
+    //debug_pub = it_.advertise("image_debug", 1);
+    cam_info_service = nh_.advertiseService("set_camera_info", &DetectorNode::setCameraInfoCb, this);
+    counter = 0;
 
-    double nn_match_threshold;
-    int ransac_n_points_to_match;
+    nh_.param<double>("nn_match_threshold", nn_match_threshold, 0.65); //0.55
+    nh_.param<int>("ransac_n_points_to_match", ransac_n_points_to_match, 4); //4
 
-    //uncomment corresponding lines if need debug stuff
-    //image_transport::Publisher debug_pub;
+}
 
-public:
-    DetectorNode(std::string root = ".")
-        : nh_("blort_detector"), it_(nh_), root_(root), detector(0)
+DetectorNode::~DetectorNode()
+{
+    if(detector != 0)
+        delete(detector);
+}
+
+bool DetectorNode::recovery(blort_ros::RecoveryCall::Request &req,
+              blort_ros::RecoveryCall::Response &resp)
+{
+    if(detector != 0)
     {
-        cam_info_sub = nh_.subscribe("/blort_camera_info", 1, &DetectorNode::cam_info_callback, this);
-        image_pub = it_.advertise("image_result", 1);
-        //debug_pub = it_.advertise("image_debug", 1);
-        cam_info_service = nh_.advertiseService("set_camera_info", &DetectorNode::setCameraInfoCb, this);
-        counter = 0;
-
-        nh_.param<double>("nn_match_threshold", nn_match_threshold, 0.65); //0.55
-        nh_.param<int>("ransac_n_points_to_match", ransac_n_points_to_match, 4); //4
-
-    }
-    
-    ~DetectorNode()
-    {
-        if(detector != 0)
-            delete(detector);
-    }
-
-    bool recovery(blort_ros::RecoveryCall::Request &req,
-                  blort_ros::RecoveryCall::Response &resp)
-    {
-        if(detector != 0)
+        ROS_INFO("Detector called the %u-th time.", ++counter);
+        bool result;
+        resp.object_ids = req.object_ids;
+        std::vector<size_t> object_ids;
+        for(size_t i = 0; i < req.object_ids.size(); ++i)
         {
-            ROS_INFO("Detector called the %u-th time.", ++counter);
-            bool result;
-            resp.object_id = req.object_id;
-            if(!req.Image.data.empty())
+            object_ids.push_back(req.object_ids[i].data);
+        }
+        if(!req.Image.data.empty())
+        {
+            cv_bridge::CvImagePtr cv_ptr;
+            try
             {
-                cv_bridge::CvImagePtr cv_ptr;
-                try
-                {
-                    //cv_ptr = cv_bridge::toCvCopy(req.Image, sensor_msgs::image_encodings::BGR8);
-                  cv_ptr = cv_bridge::toCvCopy(req.Image, req.Image.encoding);
-                  ROS_INFO_STREAM("\n\nENCODING = " << req.Image.encoding << "\n\n\n");
-                }
-                catch (cv_bridge::Exception& e)
-                {
-                    ROS_ERROR("cv_bridge exception: %s", e.what());
-                    return false;
-                }
-                result = detector->recovery(req.object_id.data, cv_ptr->image, resp);
-            } else {
-                ROS_INFO("Running detector on latest image.");
-                result = detector->recoveryWithLast(req.object_id.data, resp);
+                //cv_ptr = cv_bridge::toCvCopy(req.Image, sensor_msgs::image_encodings::BGR8);
+              cv_ptr = cv_bridge::toCvCopy(req.Image, req.Image.encoding);
+              ROS_INFO_STREAM("\n\nENCODING = " << req.Image.encoding << "\n\n\n");
             }
-            cv_bridge::CvImage out_msg;
-            out_msg.header = req.Image.header;
-            out_msg.header.stamp = ros::Time::now();
-            //out_msg.encoding = sensor_msgs::image_encodings::TYPE_8UC3;
-            out_msg.encoding = sensor_msgs::image_encodings::BGR8;
-            out_msg.image = detector->getImage();
-            image_pub.publish(out_msg.toImageMsg());
-
-//            cv_bridge::CvImage debug_msg;
-//            debug_msg.header = req.Image.header;
-//            debug_msg.header.stamp = ros::Time::now();
-//            debug_msg.encoding = sensor_msgs::image_encodings::TYPE_8UC3;
-//            debug_msg.image = detector->getDebugImage();
-//            debug_pub.publish(debug_msg.toImageMsg());
-
-            ROS_INFO("\n");
-            ROS_INFO_STREAM("= > detector_node returned " << result << "\n");
-            ROS_INFO("\n");
-
-            return result;
+            catch (cv_bridge::Exception& e)
+            {
+                ROS_ERROR("cv_bridge exception: %s", e.what());
+                return false;
+            }
+            result = detector->recovery(object_ids, cv_ptr->image, resp);
         } else {
-            ROS_ERROR("blort_detector service called while the core is uninitialized.");
-            return false;
+            ROS_INFO("Running detector on latest image.");
+            result = detector->recoveryWithLast(object_ids, resp);
         }
-    }
+        cv_bridge::CvImage out_msg;
+        out_msg.header = req.Image.header;
+        out_msg.header.stamp = ros::Time::now();
+        //out_msg.encoding = sensor_msgs::image_encodings::TYPE_8UC3;
+        out_msg.encoding = sensor_msgs::image_encodings::BGR8;
+        out_msg.image = detector->getImage();
+        image_pub.publish(out_msg.toImageMsg());
+        ROS_INFO_STREAM("= > detector_node returned " << result);
 
-    bool setCameraInfoCb(blort_ros::SetCameraInfo::Request &req,
-                         blort_ros::SetCameraInfo::Response &resp)
-    {
-        if(detector == 0)
-            cam_info_callback(req.CameraInfo);
-        return true;
+        return result;
+    } else {
+        ROS_ERROR("blort_detector service called while the core is uninitialized.");
+        return false;
     }
+}
 
-    void reconf_callback(blort_ros::DetectorConfig &config, uint32_t level)
+bool DetectorNode::setCameraInfoCb(blort_ros::SetCameraInfo::Request &req,
+                     blort_ros::SetCameraInfo::Response &resp)
+{
+    if(detector == 0)
+        cam_info_callback(req.CameraInfo);
+    return true;
+}
+
+void DetectorNode::reconf_callback(blort_ros::DetectorConfig &config, uint32_t level)
+{
+    if(detector != 0)
     {
-        if(detector != 0)
-        {
-            detector->reconfigure(config);
-            ROS_INFO("Detector confidence threshold set to %f", config.recovery_conf_threshold);
-        } else {
-            ROS_WARN("Please publish camera_info for the tracker initialization.");
-        }
+        detector->reconfigure(config);
+        ROS_INFO("Detector confidence threshold set to %f", config.recovery_conf_threshold);
+    } else {
+        ROS_WARN("Please publish camera_info for the tracker initialization.");
     }
-    
-    void cam_info_callback(const sensor_msgs::CameraInfo &msg)
+}
+
+void DetectorNode::cam_info_callback(const sensor_msgs::CameraInfo &msg)
+{
+    if(detector == 0)
     {
-        if(detector == 0)
-        {
-            ROS_INFO("Camera parameters received, ready to run.");
-            cam_info_sub.shutdown();
-            detector = new blort_ros::GLDetector(msg, root_);
-            if(nn_match_threshold != 0.0)
-                detector->setNNThreshold(nn_match_threshold);
-            if(ransac_n_points_to_match != 0)
-                detector->setRansacNPointsToMatch(ransac_n_points_to_match);
-            pose_service = nh_.advertiseService("pose_service", &DetectorNode::recovery, this);
-            // lines for dynamic_reconfigure
-            server_ = std::auto_ptr<dynamic_reconfigure::Server<blort_ros::DetectorConfig> >
-                      (new dynamic_reconfigure::Server<blort_ros::DetectorConfig>());
-            f_ = boost::bind(&DetectorNode::reconf_callback, this, _1, _2);
-            server_->setCallback(f_);
-        }
+        ROS_INFO("Camera parameters received, ready to run.");
+        cam_info_sub.shutdown();
+        detector = new blort_ros::GLDetector(msg, root_);
+        if(nn_match_threshold != 0.0)
+            detector->setNNThreshold(nn_match_threshold);
+        if(ransac_n_points_to_match != 0)
+            detector->setRansacNPointsToMatch(ransac_n_points_to_match);
+        pose_service = nh_.advertiseService("pose_service", &DetectorNode::recovery, this);
+        // lines for dynamic_reconfigure
+        server_ = std::auto_ptr<dynamic_reconfigure::Server<blort_ros::DetectorConfig> >
+                  (new dynamic_reconfigure::Server<blort_ros::DetectorConfig>());
+        f_ = boost::bind(&DetectorNode::reconf_callback, this, _1, _2);
+        server_->setCallback(f_);
     }
-};
+}
 
 int main(int argc, char *argv[] )
 {

--- a/blort_ros/src/nodes/detector_node.h
+++ b/blort_ros/src/nodes/detector_node.h
@@ -1,0 +1,87 @@
+/*
+ * Software License Agreement (Modified BSD License)
+ *
+ *  Copyright (c) 2012, PAL Robotics, S.L.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PAL Robotics, S.L. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE. 
+ *
+ * @file detector_node.cpp
+ * @author Bence Magyar
+ * @date June 2012
+ * @version 0.2
+ * @brief Main file of BLORT detector node for ROS.
+ */
+
+#include <ros/ros.h>
+#include <opencv2/core/core.hpp>
+#include <image_transport/image_transport.h>
+#include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
+#include <dynamic_reconfigure/server.h>
+#include <blort_ros/DetectorConfig.h>
+#include <blort_ros/SetCameraInfo.h>
+#include "../gldetector.h"
+
+class DetectorNode
+{
+private:
+    ros::NodeHandle nh_;
+    image_transport::ImageTransport it_;
+    image_transport::Publisher image_pub;
+    ros::Subscriber cam_info_sub;
+    const std::string root_;
+    ros::ServiceServer pose_service;
+    ros::ServiceServer cam_info_service;
+    std::auto_ptr<dynamic_reconfigure::Server<blort_ros::DetectorConfig> > server_;
+    dynamic_reconfigure::Server<blort_ros::DetectorConfig>::CallbackType f_;
+    blort_ros::GLDetector* detector;
+    unsigned int counter;
+
+    double nn_match_threshold;
+    int ransac_n_points_to_match;
+
+    //uncomment corresponding lines if need debug stuff
+    //image_transport::Publisher debug_pub;
+
+public:
+    DetectorNode(std::string root = ".");
+
+    ~DetectorNode();
+
+    bool recovery(blort_ros::RecoveryCall::Request &req,
+                  blort_ros::RecoveryCall::Response &resp);
+
+    bool setCameraInfoCb(blort_ros::SetCameraInfo::Request &req,
+                         blort_ros::SetCameraInfo::Response &resp);
+
+    void reconf_callback(blort_ros::DetectorConfig &config, uint32_t level);
+    
+    void cam_info_callback(const sensor_msgs::CameraInfo &msg);
+};
+

--- a/blort_ros/src/nodes/learnsifts.cpp
+++ b/blort_ros/src/nodes/learnsifts.cpp
@@ -132,9 +132,11 @@ int main(int argc, char *argv[] )
     //FIXME: make these ROS parameters or eliminate them and use the content as parameters
     std::string pose_cal = pal_blort::addRoot("bin/pose.cal", config_root);
     std::string tracking_ini(pal_blort::addRoot("bin/tracking.ini", config_root));
+    std::vector<std::string> ply_models, sift_files, model_names;
     std::string ply_model, sift_file, model_name;
 
-    GetPlySiftFilenames(tracking_ini.c_str(), ply_model, sift_file, model_name);
+    GetPlySiftFilenames(tracking_ini.c_str(), ply_models, sift_files, model_names);
+    ply_model = ply_models[0]; sift_file = sift_files[0]; model_name = model_names[0];
     printf("Object name: %s\n", model_name.c_str());
     sift_file = pal_blort::addRoot(sift_file, config_root);
 

--- a/blort_ros/src/nodes/tracker_node.cpp
+++ b/blort_ros/src/nodes/tracker_node.cpp
@@ -170,6 +170,10 @@ public:
                 tracker->process(cv_tracker_ptr->image);
                 for(size_t i = 0; i < tracker->getModes().size(); ++i)
                 {
+                      if(tracker->getModes()[i] == blort_ros::TRACKER_RECOVERY_MODE)
+                      {
+                          continue;
+                      }
                       confidences_pub.publish(*(tracker->getConfidences()[i]));
                       if(tracker->getConfidence()[i] == blort_ros::TRACKER_CONF_GOOD ||
                           (tracker->getConfidence()[i] == blort_ros::TRACKER_CONF_FAIR && tracker->getPublishMode() == blort_ros::TRACKER_PUBLISH_ALL) )

--- a/blort_ros/src/nodes/tracker_node.cpp
+++ b/blort_ros/src/nodes/tracker_node.cpp
@@ -340,12 +340,12 @@ bool TrackerNode::SingleShotMode::singleShotService(blort_ros::EstimatePose::Req
                 {
                     ROS_INFO("Remaining time %f", time_to_run_singleshot+start_secs-ros::Time::now().toSec());
                     parent_->imageCb(lastImage, lastImage);
-                    if(parent_->tracker->getConfidence() == blort_ros::TRACKER_CONF_GOOD)
+                    if(parent_->tracker->getConfidence()[0] == blort_ros::TRACKER_CONF_GOOD)
                     {
                         // instead of returning right away let's store the result
                         // to see if the tracker can get better
                         results.push_back(parent_->tracker->getDetections()[0]);
-                    } else if(parent_->tracker->getConfidence() == blort_ros::TRACKER_CONF_LOST)
+                    } else if(parent_->tracker->getConfidence()[0] == blort_ros::TRACKER_CONF_LOST)
                     {
                         results.clear();
                     }

--- a/blort_ros/src/nodes/tracker_node.cpp
+++ b/blort_ros/src/nodes/tracker_node.cpp
@@ -1,429 +1,305 @@
-/*
- * Software License Agreement (Modified BSD License)
- *
- *  Copyright (c) 2012, PAL Robotics, S.L.
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions
- *  are met:
- *
- *   * Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above
- *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials provided
- *     with the distribution.
- *   * Neither the name of PAL Robotics, S.L. nor the names of its
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *  POSSIBILITY OF SUCH DAMAGE. 
- *
- * @file tracker_node.cpp
- * @author Bence Magyar
- * @date May 2012
- * @version 0.2
- * @brief Main file of BLORT tracker node for ROS.
- */
+#include "tracker_node.h"
 
-#include <ros/ros.h>
-#include <opencv2/core/core.hpp>
-#include <ros/duration.h>
-#include <ros/time.h>
-
-#include <image_transport/image_transport.h>
-#include <image_transport/subscriber_filter.h>
-#include <message_filters/time_synchronizer.h>
-#include <cv_bridge/cv_bridge.h>
-#include <sensor_msgs/image_encodings.h>
-#include <geometry_msgs/Pose.h>
-#include <dynamic_reconfigure/server.h>
-
-#include <blort_ros/TrackerResults.h>
-#include <blort_ros/TrackerConfig.h>
-#include <blort_ros/TrackerCommand.h>
-#include <blort_ros/RecoveryCall.h>
-#include <blort_ros/EstimatePose.h>
-#include <blort_ros/SetCameraInfo.h>
-#include <blort/GLWindow/glxhidingwindow.h>
-#include <blort/blort/pal_util.h>
-#include "../gltracker.h"
-#include <boost/noncopyable.hpp>
-
-class TrackerNode : boost::noncopyable
+TrackerNode::TrackerNode(std::string root)
+    : nh_("blort_tracker"), it_(nh_), pose_seq(0), camera_frame_id("0"), root_(root), tracker(0)
 {
-private:
-    class Mode;
-    class TrackingMode;
-    class SingleShotMode;
+    nh_.param<std::string>("launch_mode", launch_mode, "tracking");
+    detection_result = nh_.advertise<blort_ros::TrackerResults>("detection_result", 100);
+    confidences_pub = nh_.advertise<blort_ros::TrackerConfidences>("confidences", 100);
+    image_pub = it_.advertise("image_result", 1);
 
-private:
-    ros::NodeHandle nh_;
-    image_transport::ImageTransport it_;
-    image_transport::Publisher image_pub;
-    image_transport::Publisher image_debug_pub;
-    ros::Publisher detection_result;
-    ros::Publisher confidences_pub;
-
-    //sensor_msgs::CameraInfo _msg;
-    unsigned int pose_seq;
-    std::string camera_frame_id;
-
-    const std::string root_;
-    ros::ServiceServer control_service;
-    std::auto_ptr<dynamic_reconfigure::Server<blort_ros::TrackerConfig> > server_;
-    dynamic_reconfigure::Server<blort_ros::TrackerConfig>::CallbackType f_;
-    ros::ServiceClient recovery_client;
-    blort_ros::GLTracker* tracker;
-    std::string launch_mode;
-
-    Mode* mode;
-public:
-    
-    TrackerNode(std::string root = ".")
-        : nh_("blort_tracker"), it_(nh_), pose_seq(0), camera_frame_id("0"), root_(root), tracker(0)
+    if(launch_mode == "tracking")
     {
-        nh_.param<std::string>("launch_mode", launch_mode, "tracking");
-        detection_result = nh_.advertise<blort_ros::TrackerResults>("detection_result", 100);
-        confidences_pub = nh_.advertise<blort_ros::TrackerConfidences>("confidences", 100);
-        image_pub = it_.advertise("image_result", 1);
+        mode = new TrackingMode(this);
+    }else if(launch_mode == "singleshot")
+    {
+        mode = new SingleShotMode(this);
+    } else {
+        ROS_FATAL("Invalid launch_mode parameter passed to blort_tracker.");
+    }
+}
 
-        if(launch_mode == "tracking")
+TrackerNode::~TrackerNode()
+{
+    if(tracker != 0)
+        delete(tracker);
+    delete mode;
+}
+
+void TrackerNode::setCameraFrameID(const std::string & id)
+{
+    camera_frame_id = id;
+}
+
+void TrackerNode::imageCb(const sensor_msgs::ImageConstPtr& detectorImgMsg, const sensor_msgs::ImageConstPtr& trackerImgMsg )
+{
+    if(tracker != 0)
+    {
+        cv_bridge::CvImagePtr cv_detector_ptr, cv_tracker_ptr;
+        try
         {
-            mode = new TrackingMode(this);
-        }else if(launch_mode == "singleshot")
-        {
-            mode = new SingleShotMode(this);
-        } else {
-            ROS_FATAL("Invalid launch_mode parameter passed to blort_tracker.");
+            cv_detector_ptr = cv_bridge::toCvCopy(detectorImgMsg, sensor_msgs::image_encodings::BGR8);
+            cv_tracker_ptr  = cv_bridge::toCvCopy(trackerImgMsg,  sensor_msgs::image_encodings::BGR8);
         }
-    }
-    
-    ~TrackerNode()
-    {
-        if(tracker != 0)
-            delete(tracker);
-        delete mode;
-    }
-
-    void setCameraFrameID(const std::string & id)
-    {
-        camera_frame_id = id;
-    }
-    
-    void imageCb(const sensor_msgs::ImageConstPtr& detectorImgMsg, const sensor_msgs::ImageConstPtr& trackerImgMsg )
-    {
-        if(tracker != 0)
+        catch (cv_bridge::Exception& e)
         {
-            cv_bridge::CvImagePtr cv_detector_ptr, cv_tracker_ptr;
-            try
-            {
-                cv_detector_ptr = cv_bridge::toCvCopy(detectorImgMsg, sensor_msgs::image_encodings::BGR8);
-                cv_tracker_ptr  = cv_bridge::toCvCopy(trackerImgMsg,  sensor_msgs::image_encodings::BGR8);
-            }
-            catch (cv_bridge::Exception& e)
-            {
-                ROS_ERROR("cv_bridge exception: %s", e.what());
-                return;
-            }
+            ROS_ERROR("cv_bridge exception: %s", e.what());
+            return;
+        }
 
-            bool should_process = false;
+        bool should_process = false;
+        for(size_t i = 0; i < tracker->getModes().size(); ++i)
+        {
+            if(tracker->getModes()[i] == blort_ros::TRACKER_RECOVERY_MODE)
+            {              
+                blort_ros::RecoveryCall srv = mode->recovery(i, detectorImgMsg);
+
+                ros::Time before = ros::Time::now();
+                ROS_INFO_STREAM("tracker_node in TRACKER_RECOVERY_MODE: calling detector_node recovery service for object " << tracker->getModelNames()[i]);
+                if(recovery_client.call(srv))
+                {
+                  //tracker = new blort_ros::GLTracker(_msg, root_, true);
+                  ROS_INFO("reseting tracker with pose from detector");
+                  tracker->resetWithPose(i, srv.response.Pose);
+                  ROS_INFO("AFTER reseting tracker with pose from detector");
+                }
+                else
+                {
+                    ROS_WARN("Detector not confident enough.");
+                }
+                ROS_INFO_STREAM("Recovery call took " << (ros::Time::now() - before));
+            }
+            else //TRACKER_TRACKING_MODE or TRACKER_LOCKED_MODE
+            {
+              should_process = true;
+            }
+        }
+        if(should_process)
+        {
+            ROS_INFO("----------------------------------------------");
+            ROS_INFO("TrackerNode::imageCb: calling tracker->process");
+            tracker->process(cv_tracker_ptr->image);
             for(size_t i = 0; i < tracker->getModes().size(); ++i)
             {
-                if(tracker->getModes()[i] == blort_ros::TRACKER_RECOVERY_MODE)
-                {              
-                    blort_ros::RecoveryCall srv = mode->recovery(i, detectorImgMsg);
+                  if(tracker->getModes()[i] == blort_ros::TRACKER_RECOVERY_MODE)
+                  {
+                      continue;
+                  }
+                  confidences_pub.publish(*(tracker->getConfidences()[i]));
+                  if(tracker->getConfidence()[i] == blort_ros::TRACKER_CONF_GOOD ||
+                      (tracker->getConfidence()[i] == blort_ros::TRACKER_CONF_FAIR && tracker->getPublishMode() == blort_ros::TRACKER_PUBLISH_ALL) )
+                  {
+                      blort_ros::TrackerResults msg;
+                      msg.obj_name.data = tracker->getModelNames()[i];
+                      msg.pose.header.seq = pose_seq++;
+                      msg.pose.header.stamp = ros::Time::now();
+                      msg.pose.header.frame_id = camera_frame_id;
+                      msg.pose.pose = pal_blort::blortPosesToRosPose(tracker->getCameraReferencePose(),
+                                                                                       tracker->getDetections()[i]);
 
-                    ROS_INFO("tracker_node in TRACKER_RECOVERY_MODE: calling detector_node recovery service ...");
-                    if(recovery_client.call(srv))
-                    {
-                      //tracker = new blort_ros::GLTracker(_msg, root_, true);
-                      ROS_INFO("reseting tracker with pose from detector\n");
-                      tracker->resetWithPose(i, srv.response.Pose);
-                      ROS_INFO("AFTER reseting tracker with pose from detector\n");
-                    }
-                    else
-                    {
-                        ROS_WARN("Detector not confident enough.\n");
-                    }
-                }
-                else //TRACKER_TRACKING_MODE or TRACKER_LOCKED_MODE
-                {
-                  should_process = true;
-                }
+                      detection_result.publish(msg);
+                  }
             }
-            if(should_process)
-            {
-                ROS_INFO("\n----------------------------------------------\n");
-                ROS_INFO("TrackerNode::imageCb: calling tracker->process");
-                tracker->process(cv_tracker_ptr->image);
-                for(size_t i = 0; i < tracker->getModes().size(); ++i)
-                {
-                      if(tracker->getModes()[i] == blort_ros::TRACKER_RECOVERY_MODE)
-                      {
-                          continue;
-                      }
-                      confidences_pub.publish(*(tracker->getConfidences()[i]));
-                      if(tracker->getConfidence()[i] == blort_ros::TRACKER_CONF_GOOD ||
-                          (tracker->getConfidence()[i] == blort_ros::TRACKER_CONF_FAIR && tracker->getPublishMode() == blort_ros::TRACKER_PUBLISH_ALL) )
-                      {
-                          blort_ros::TrackerResults msg;
-                          msg.obj_name.data = tracker->getModelNames()[i];
-                          msg.pose.header.seq = pose_seq++;
-                          msg.pose.header.stamp = ros::Time::now();
-                          msg.pose.header.frame_id = camera_frame_id;
-                          msg.pose.pose = pal_blort::blortPosesToRosPose(tracker->getCameraReferencePose(),
-                                                                                           tracker->getDetections()[i]);
-
-                          detection_result.publish(msg);
-                      }
-                }
-                cv_bridge::CvImage out_msg;
-                out_msg.header = trackerImgMsg->header;
-                out_msg.header.stamp = ros::Time::now();
-                //out_msg.encoding = sensor_msgs::image_encodings::TYPE_8UC3;
-                out_msg.encoding = sensor_msgs::image_encodings::BGR8;
-                out_msg.image = tracker->getImage();
-                image_pub.publish(out_msg.toImageMsg());
-            }
+            cv_bridge::CvImage out_msg;
+            out_msg.header = trackerImgMsg->header;
+            out_msg.header.stamp = ros::Time::now();
+            //out_msg.encoding = sensor_msgs::image_encodings::TYPE_8UC3;
+            out_msg.encoding = sensor_msgs::image_encodings::BGR8;
+            out_msg.image = tracker->getImage();
+            image_pub.publish(out_msg.toImageMsg());
         }
     }
-    
-    bool trackerControlServiceCb(blort_ros::TrackerCommand::Request &req,
-                                 blort_ros::TrackerCommand::Response &)
+}
+
+bool TrackerNode::trackerControlServiceCb(blort_ros::TrackerCommand::Request &req,
+                             blort_ros::TrackerCommand::Response &)
+{
+    if(tracker != 0)
     {
-        if(tracker != 0)
+        tracker->trackerControl(req.code, req.param);
+        return true;
+    } else {
+        ROS_WARN("Please publish camera_info for the tracker initialization.");
+        return false;
+    }
+}
+
+// STATE DESIGN PATTERN
+// to implement the different tracker modes
+TrackerNode::TrackingMode::TrackingMode(TrackerNode* parent) : parent_(parent)
+{
+    ROS_INFO("Blort tracker launched in tracking mode.");
+    cam_info_sub = parent_->nh_.subscribe("/detector_camera_info", 10, &TrackerNode::TrackingMode::cam_info_callback, this);
+}
+
+void TrackerNode::TrackingMode::reconf_callback(blort_ros::TrackerConfig &config, uint32_t level)
+{
+    if(parent_->tracker != 0)
+    {
+        parent_->tracker->reconfigure(config);
+    } else {
+        ROS_WARN("Please publish camera_info for the tracker initialization.");
+    }
+}
+
+blort_ros::RecoveryCall TrackerNode::TrackingMode::recovery(size_t i, const sensor_msgs::ImageConstPtr& msg)
+{
+    blort_ros::RecoveryCall srv;
+    srv.request.object_id.data = i;
+    srv.request.Image = *msg;
+    return srv;
+}
+
+// The real initialization is being done after receiving the camerainfo.
+void TrackerNode::TrackingMode::cam_info_callback(const sensor_msgs::CameraInfo &msg)
+{
+    if(parent_->tracker == 0)
+    {
+        ROS_INFO("Camera parameters received, ready to run.");
+        parent_->setCameraFrameID(msg.header.frame_id);
+        //parent_->_msg = msg; //2012-11-27 Jordi: keep a copy to reset the tracker when necessary
+        cam_info_sub.shutdown();
+        parent_->tracker = new blort_ros::GLTracker(msg, parent_->root_, true);
+        parent_->tracker->setVisualizeObjPose(true);
+
+        image_transport::TransportHints transportHint("raw");
+
+        detector_image_sub.reset( new image_transport::SubscriberFilter(parent_->it_, "/detector_image",   1, transportHint) );
+        tracker_image_sub.reset( new image_transport::SubscriberFilter(parent_->it_, "/tracker_image",   1, transportHint) );
+
+        imageSynchronizer.reset( new message_filters::TimeSynchronizer<sensor_msgs::Image,
+                                                                       sensor_msgs::Image>(*detector_image_sub, *tracker_image_sub, 1) );
+
+        imageSynchronizer->registerCallback(boost::bind(&TrackerNode::imageCb, parent_, _1, _2));
+
+        parent_->control_service = parent_->nh_.advertiseService("tracker_control", &TrackerNode::trackerControlServiceCb, parent_);
+        parent_->server_ = std::auto_ptr<dynamic_reconfigure::Server<blort_ros::TrackerConfig> >
+                           (new dynamic_reconfigure::Server<blort_ros::TrackerConfig>());
+        parent_->f_ = boost::bind(&TrackerNode::TrackingMode::reconf_callback, this, _1, _2);
+        parent_->server_->setCallback(parent_->f_);
+        parent_->recovery_client = parent_->nh_.serviceClient<blort_ros::RecoveryCall>("/blort_detector/pose_service");
+    }
+}
+
+TrackerNode::SingleShotMode::SingleShotMode(TrackerNode* parent) : parent_(parent)
+{
+    ROS_INFO("Blort tracker launched in singleshot mode.");
+    detector_set_caminfo_service = parent_->nh_.serviceClient<blort_ros::SetCameraInfo>("/blort_detector/set_camera_info");
+    singleshot_service = parent_->nh_.advertiseService("singleshot_service", &TrackerNode::SingleShotMode::singleShotService, this);
+    image_sub = parent_->it_.subscribe("/blort_image_rect_masked", 10, &TrackerNode::SingleShotMode::imageCallback, this);
+    cam_info_sub = parent_->nh_.subscribe("/detector_camera_info", 10, &TrackerNode::SingleShotMode::cameraCallback, this);
+
+    parent_->control_service = parent_->nh_.advertiseService("tracker_control", &TrackerNode::trackerControlServiceCb, parent_);
+    parent_->server_ = std::auto_ptr<dynamic_reconfigure::Server<blort_ros::TrackerConfig> >
+                       (new dynamic_reconfigure::Server<blort_ros::TrackerConfig>());
+    parent_->f_ = boost::bind(&SingleShotMode::reconf_callback, this, _1, _2);
+    parent_->server_->setCallback(parent_->f_);
+
+    time_to_run_singleshot = 10.;
+    inServiceCall = false;
+}
+
+void TrackerNode::SingleShotMode::imageCallback(const sensor_msgs::ImageConstPtr &image)
+{
+    if(!inServiceCall)
+    {
+        // if there is no ongoing servicecall, we can receive the new infos
+        // if we are in an ongoing servicecall, these fields should be constant
+        lastImage = image;
+    }
+}
+
+void TrackerNode::SingleShotMode::cameraCallback(const sensor_msgs::CameraInfoConstPtr &camera_info)
+{
+    if(!inServiceCall)
+    {
+        // if there is no ongoing servicecall, we can receive the new infos
+        // if we are in an ongoing servicecall, these fields should be constant
+        lastCameraInfo = camera_info;
+    }
+}
+
+void TrackerNode::SingleShotMode::reconf_callback(blort_ros::TrackerConfig &config, uint32_t level)
+{
+    time_to_run_singleshot =  config.time_to_run_singleshot;
+}
+
+blort_ros::RecoveryCall TrackerNode::SingleShotMode::recovery(size_t i, const sensor_msgs::ImageConstPtr& msg)
+{
+    blort_ros::RecoveryCall srv;
+    if(!inServiceCall)
+    {
+        srv.request.object_id.data = i;
+        srv.request.Image = *msg;
+        // we step into the service call "state" with the first recoverycall made
+        // no new images are accepted until the end of the singleShotServiceCall
+        inServiceCall = true;
+    }
+    return srv;
+}
+
+/* FIXME Implement single-shot with object selection */
+/* For now, single-shot runs on first object for backward compatibility */
+bool TrackerNode::SingleShotMode::singleShotService(blort_ros::EstimatePose::Request &req,
+                       blort_ros::EstimatePose::Response &resp)
+{
+    if(lastImage.use_count() < 1 && lastCameraInfo.use_count() < 1)
+    {
+        ROS_ERROR("Service called but there was no data on the input topics!");
+        return false;
+    } else {
+
+        ROS_INFO("Singleshot service has been called with a timeout of %f seconds.", time_to_run_singleshot);
+        results.clear();
+
+        if(parent_->tracker == 0)
         {
-            tracker->trackerControl(req.code, req.param);
+            parent_->tracker = new blort_ros::GLTracker(*lastCameraInfo, parent_->root_, true);
+            parent_->recovery_client = parent_->nh_.serviceClient<blort_ros::RecoveryCall>("/blort_detector/poseService");
+        } else {
+            parent_->tracker->reset();
+        }
+        parent_->tracker->setPublishMode(blort_ros::TRACKER_PUBLISH_GOOD);
+        parent_->tracker->setVisualizeObjPose(true);
+        blort_ros::SetCameraInfo camera_info;
+        camera_info.request.CameraInfo = *lastCameraInfo;
+        if(!detector_set_caminfo_service.call(camera_info))
+            ROS_ERROR("blort_tracker failed to call blort_detector/set_camera_info service");
+
+        double start_secs = ros::Time::now().toSec();
+        while(ros::Time::now().toSec()-start_secs < time_to_run_singleshot)
+        {
+            ROS_INFO("Remaining time %f", time_to_run_singleshot+start_secs-ros::Time::now().toSec());
+            parent_->imageCb(lastImage, lastImage);
+            if(parent_->tracker->getConfidence()[0] == blort_ros::TRACKER_CONF_GOOD)
+            {
+                // instead of returning right away let's store the result
+                // to see if the tracker can get better
+                results.push_back(parent_->tracker->getDetections()[0]);
+            } else if(parent_->tracker->getConfidence()[0] == blort_ros::TRACKER_CONF_LOST)
+            {
+                results.clear();
+            }
+        }
+        // we are out of the service call now, the results will be published
+        inServiceCall = false;
+        if(!results.empty())
+        {
+            //convert results to a tf style transform and multiply them
+            //to get the camera-to-target transformation
+            resp.Pose = pal_blort::blortPosesToRosPose(parent_->tracker->getCameraReferencePose(),
+                                                       results.back());
+            //NOTE: check the pose in vec3 location + mat3x3 rotation could be added here
+            // if we have any previous knowledge of the given scene
+            ROS_INFO_STREAM("PUBLISHED POSE:" << std::endl << resp.Pose.position << std::endl <<
+                            pal_blort::quaternionTo3x3cvMat(resp.Pose.orientation) << std::endl);
             return true;
         } else {
-            ROS_WARN("Please publish camera_info for the tracker initialization.");
+            //if the time was not enough to get a good detection, make the whole thing fail
             return false;
         }
     }
-
-    // STATE DESIGN PATTERN
-    // to implement the different tracker modes
-private:
-    class Mode
-    {
-    public:
-        virtual void reconf_callback(blort_ros::TrackerConfig &config, uint32_t level) = 0;
-        virtual blort_ros::RecoveryCall recovery(size_t i, const sensor_msgs::ImageConstPtr& msg) = 0;
-    };
-
-    class TrackingMode : public Mode
-    {
-    private:
-        ros::Subscriber cam_info_sub;        
-        boost::shared_ptr<image_transport::SubscriberFilter> detector_image_sub, tracker_image_sub;
-        boost::shared_ptr< message_filters::TimeSynchronizer<sensor_msgs::Image, sensor_msgs::Image > > imageSynchronizer;
-        TrackerNode* parent_;
-    public:
-        TrackingMode(TrackerNode* parent) : parent_(parent)
-        {
-            ROS_INFO("Blort tracker launched in tracking mode.");
-            cam_info_sub = parent_->nh_.subscribe("/detector_camera_info", 10, &TrackerNode::TrackingMode::cam_info_callback, this);
-        }
-
-        virtual void reconf_callback(blort_ros::TrackerConfig &config, uint32_t level)
-        {
-            if(parent_->tracker != 0)
-            {
-                parent_->tracker->reconfigure(config);
-            } else {
-                ROS_WARN("Please publish camera_info for the tracker initialization.");
-            }
-        }
-
-        virtual blort_ros::RecoveryCall recovery(size_t i, const sensor_msgs::ImageConstPtr& msg)
-        {
-            blort_ros::RecoveryCall srv;
-            srv.request.object_id.data = i;
-            srv.request.Image = *msg;
-            return srv;
-        }
-
-        // The real initialization is being done after receiving the camerainfo.
-        void cam_info_callback(const sensor_msgs::CameraInfo &msg)
-        {
-            if(parent_->tracker == 0)
-            {
-                ROS_INFO("Camera parameters received, ready to run.");
-                parent_->setCameraFrameID(msg.header.frame_id);
-                //parent_->_msg = msg; //2012-11-27 Jordi: keep a copy to reset the tracker when necessary
-                cam_info_sub.shutdown();
-                parent_->tracker = new blort_ros::GLTracker(msg, parent_->root_, true);
-                parent_->tracker->setVisualizeObjPose(true);
-
-                image_transport::TransportHints transportHint("raw");
-
-                detector_image_sub.reset( new image_transport::SubscriberFilter(parent_->it_, "/detector_image",   1, transportHint) );
-                tracker_image_sub.reset( new image_transport::SubscriberFilter(parent_->it_, "/tracker_image",   1, transportHint) );
-
-                imageSynchronizer.reset( new message_filters::TimeSynchronizer<sensor_msgs::Image,
-                                                                               sensor_msgs::Image>(*detector_image_sub, *tracker_image_sub, 1) );
-
-                imageSynchronizer->registerCallback(boost::bind(&TrackerNode::imageCb, parent_, _1, _2));
-
-                parent_->control_service = parent_->nh_.advertiseService("tracker_control", &TrackerNode::trackerControlServiceCb, parent_);
-                parent_->server_ = std::auto_ptr<dynamic_reconfigure::Server<blort_ros::TrackerConfig> >
-                                   (new dynamic_reconfigure::Server<blort_ros::TrackerConfig>());
-                parent_->f_ = boost::bind(&TrackerNode::TrackingMode::reconf_callback, this, _1, _2);
-                parent_->server_->setCallback(parent_->f_);
-                parent_->recovery_client = parent_->nh_.serviceClient<blort_ros::RecoveryCall>("/blort_detector/pose_service");
-            }
-        }
-    };
-
-    class SingleShotMode : public Mode
-    {
-    private:
-        ros::ServiceServer singleshot_service;
-        double time_to_run_singleshot;
-        ros::ServiceClient detector_set_caminfo_service;
-        bool inServiceCall;
-        TrackerNode* parent_;
-        std::list<geometry_msgs::Pose> results;
-
-        ros::Subscriber cam_info_sub;
-        image_transport::Subscriber image_sub;
-        sensor_msgs::ImageConstPtr lastImage;
-        sensor_msgs::CameraInfoConstPtr lastCameraInfo;
-    public:
-        SingleShotMode(TrackerNode* parent) : parent_(parent)
-        {
-            ROS_INFO("Blort tracker launched in singleshot mode.");
-            detector_set_caminfo_service = parent_->nh_.serviceClient<blort_ros::SetCameraInfo>("/blort_detector/set_camera_info");
-            singleshot_service = parent_->nh_.advertiseService("singleshot_service", &TrackerNode::SingleShotMode::singleShotService, this);
-            image_sub = parent_->it_.subscribe("/blort_image_rect_masked", 10, &TrackerNode::SingleShotMode::imageCallback, this);
-            cam_info_sub = parent_->nh_.subscribe("/detector_camera_info", 10, &TrackerNode::SingleShotMode::cameraCallback, this);
-
-            parent_->control_service = parent_->nh_.advertiseService("tracker_control", &TrackerNode::trackerControlServiceCb, parent_);
-            parent_->server_ = std::auto_ptr<dynamic_reconfigure::Server<blort_ros::TrackerConfig> >
-                               (new dynamic_reconfigure::Server<blort_ros::TrackerConfig>());
-            parent_->f_ = boost::bind(&SingleShotMode::reconf_callback, this, _1, _2);
-            parent_->server_->setCallback(parent_->f_);
-            
-            time_to_run_singleshot = 10.;
-            inServiceCall = false;
-        }
-
-        void imageCallback(const sensor_msgs::ImageConstPtr &image)
-        {
-            if(!inServiceCall)
-            {
-                // if there is no ongoing servicecall, we can receive the new infos
-                // if we are in an ongoing servicecall, these fields should be constant
-                lastImage = image;
-            }
-        }
-
-        void cameraCallback(const sensor_msgs::CameraInfoConstPtr &camera_info)
-        {
-            if(!inServiceCall)
-            {
-                // if there is no ongoing servicecall, we can receive the new infos
-                // if we are in an ongoing servicecall, these fields should be constant
-                lastCameraInfo = camera_info;
-            }
-        }
-
-        virtual void reconf_callback(blort_ros::TrackerConfig &config, uint32_t level)
-        {
-            time_to_run_singleshot =  config.time_to_run_singleshot;
-        }
-
-        virtual blort_ros::RecoveryCall recovery(size_t i, const sensor_msgs::ImageConstPtr& msg)
-        {
-            blort_ros::RecoveryCall srv;
-            if(!inServiceCall)
-            {
-                srv.request.object_id.data = i;
-                srv.request.Image = *msg;
-                // we step into the service call "state" with the first recoverycall made
-                // no new images are accepted until the end of the singleShotServiceCall
-                inServiceCall = true;
-            }
-            return srv;
-        }
-
-        /* FIXME Implement single-shot with object selection */
-        /* For now, single-shot runs on first object for backward compatibility */
-        bool singleShotService(blort_ros::EstimatePose::Request &req,
-                               blort_ros::EstimatePose::Response &resp)
-        {
-            if(lastImage.use_count() < 1 && lastCameraInfo.use_count() < 1)
-            {
-                ROS_ERROR("Service called but there was no data on the input topics!");
-                return false;
-            } else {
-
-                ROS_INFO("Singleshot service has been called with a timeout of %f seconds.", time_to_run_singleshot);
-                results.clear();
-
-                if(parent_->tracker == 0)
-                {
-                    parent_->tracker = new blort_ros::GLTracker(*lastCameraInfo, parent_->root_, true);
-                    parent_->recovery_client = parent_->nh_.serviceClient<blort_ros::RecoveryCall>("/blort_detector/poseService");
-                } else {
-                    parent_->tracker->reset();
-                }
-                parent_->tracker->setPublishMode(blort_ros::TRACKER_PUBLISH_GOOD);
-                parent_->tracker->setVisualizeObjPose(true);
-                blort_ros::SetCameraInfo camera_info;
-                camera_info.request.CameraInfo = *lastCameraInfo;
-                if(!detector_set_caminfo_service.call(camera_info))
-                    ROS_ERROR("blort_tracker failed to call blort_detector/set_camera_info service");
-
-                double start_secs = ros::Time::now().toSec();
-                while(ros::Time::now().toSec()-start_secs < time_to_run_singleshot)
-                {
-                    ROS_INFO("Remaining time %f", time_to_run_singleshot+start_secs-ros::Time::now().toSec());
-                    parent_->imageCb(lastImage, lastImage);
-                    if(parent_->tracker->getConfidence()[0] == blort_ros::TRACKER_CONF_GOOD)
-                    {
-                        // instead of returning right away let's store the result
-                        // to see if the tracker can get better
-                        results.push_back(parent_->tracker->getDetections()[0]);
-                    } else if(parent_->tracker->getConfidence()[0] == blort_ros::TRACKER_CONF_LOST)
-                    {
-                        results.clear();
-                    }
-                }
-                // we are out of the service call now, the results will be published
-                inServiceCall = false;
-                if(!results.empty())
-                {
-                    //convert results to a tf style transform and multiply them
-                    //to get the camera-to-target transformation
-                    resp.Pose = pal_blort::blortPosesToRosPose(parent_->tracker->getCameraReferencePose(),
-                                                               results.back());
-                    //NOTE: check the pose in vec3 location + mat3x3 rotation could be added here
-                    // if we have any previous knowledge of the given scene
-                    ROS_INFO_STREAM("PUBLISHED POSE: \n" << resp.Pose.position << "\n" <<
-                                    pal_blort::quaternionTo3x3cvMat(resp.Pose.orientation) << "\n");
-                    return true;
-                } else {
-                    //if the time was not enough to get a good detection, make the whole thing fail
-                    return false;
-                }
-            }
-        }
-    };
-};
+}
 
 int main(int argc, char *argv[] )
 {

--- a/blort_ros/src/nodes/tracker_node.h
+++ b/blort_ros/src/nodes/tracker_node.h
@@ -1,0 +1,170 @@
+/*
+ * Software License Agreement (Modified BSD License)
+ *
+ *  Copyright (c) 2012, PAL Robotics, S.L.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PAL Robotics, S.L. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE. 
+ *
+ * @file tracker_node.cpp
+ * @author Bence Magyar
+ * @date May 2012
+ * @version 0.2
+ * @brief Main file of BLORT tracker node for ROS.
+ */
+
+#ifndef _H_TRACKER_NODE_H_
+#define _H_TRACKER_NODE_H_
+
+#include <ros/ros.h>
+#include <opencv2/core/core.hpp>
+#include <ros/duration.h>
+#include <ros/time.h>
+
+#include <image_transport/image_transport.h>
+#include <image_transport/subscriber_filter.h>
+#include <message_filters/time_synchronizer.h>
+#include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
+#include <geometry_msgs/Pose.h>
+#include <dynamic_reconfigure/server.h>
+
+#include <blort_ros/TrackerResults.h>
+#include <blort_ros/TrackerConfig.h>
+#include <blort_ros/TrackerCommand.h>
+#include <blort_ros/RecoveryCall.h>
+#include <blort_ros/EstimatePose.h>
+#include <blort_ros/SetCameraInfo.h>
+#include <blort/GLWindow/glxhidingwindow.h>
+#include <blort/blort/pal_util.h>
+#include "../gltracker.h"
+#include <boost/noncopyable.hpp>
+
+class TrackerNode : boost::noncopyable
+{
+private:
+    class Mode;
+    class TrackingMode;
+    class SingleShotMode;
+
+private:
+    ros::NodeHandle nh_;
+    image_transport::ImageTransport it_;
+    image_transport::Publisher image_pub;
+    image_transport::Publisher image_debug_pub;
+    ros::Publisher detection_result;
+    ros::Publisher confidences_pub;
+
+    //sensor_msgs::CameraInfo _msg;
+    unsigned int pose_seq;
+    std::string camera_frame_id;
+
+    const std::string root_;
+    ros::ServiceServer control_service;
+    std::auto_ptr<dynamic_reconfigure::Server<blort_ros::TrackerConfig> > server_;
+    dynamic_reconfigure::Server<blort_ros::TrackerConfig>::CallbackType f_;
+    ros::ServiceClient recovery_client;
+    blort_ros::GLTracker* tracker;
+    std::string launch_mode;
+
+    Mode* mode;
+public:
+    
+    TrackerNode(std::string root = ".");
+
+    ~TrackerNode();
+
+    void setCameraFrameID(const std::string & id);
+    
+    void imageCb(const sensor_msgs::ImageConstPtr& detectorImgMsg, const sensor_msgs::ImageConstPtr& trackerImgMsg );
+    
+    bool trackerControlServiceCb(blort_ros::TrackerCommand::Request &req,
+                                 blort_ros::TrackerCommand::Response &);
+
+    // STATE DESIGN PATTERN
+    // to implement the different tracker modes
+private:
+    class Mode
+    {
+    public:
+        virtual void reconf_callback(blort_ros::TrackerConfig &config, uint32_t level) = 0;
+        virtual blort_ros::RecoveryCall recovery(size_t i, const sensor_msgs::ImageConstPtr& msg) = 0;
+    };
+
+    class TrackingMode : public Mode
+    {
+    private:
+        ros::Subscriber cam_info_sub;        
+        boost::shared_ptr<image_transport::SubscriberFilter> detector_image_sub, tracker_image_sub;
+        boost::shared_ptr< message_filters::TimeSynchronizer<sensor_msgs::Image, sensor_msgs::Image > > imageSynchronizer;
+        TrackerNode* parent_;
+    public:
+        TrackingMode(TrackerNode* parent);
+
+        virtual void reconf_callback(blort_ros::TrackerConfig &config, uint32_t level);
+
+        virtual blort_ros::RecoveryCall recovery(size_t i, const sensor_msgs::ImageConstPtr& msg);
+
+        // The real initialization is being done after receiving the camerainfo.
+        void cam_info_callback(const sensor_msgs::CameraInfo &msg);
+    };
+
+    class SingleShotMode : public Mode
+    {
+    private:
+        ros::ServiceServer singleshot_service;
+        double time_to_run_singleshot;
+        ros::ServiceClient detector_set_caminfo_service;
+        bool inServiceCall;
+        TrackerNode* parent_;
+        std::list<geometry_msgs::Pose> results;
+
+        ros::Subscriber cam_info_sub;
+        image_transport::Subscriber image_sub;
+        sensor_msgs::ImageConstPtr lastImage;
+        sensor_msgs::CameraInfoConstPtr lastCameraInfo;
+    public:
+        SingleShotMode(TrackerNode* parent);
+
+        void imageCallback(const sensor_msgs::ImageConstPtr &image);
+
+        void cameraCallback(const sensor_msgs::CameraInfoConstPtr &camera_info);
+
+        virtual void reconf_callback(blort_ros::TrackerConfig &config, uint32_t level);
+
+        virtual blort_ros::RecoveryCall recovery(size_t i, const sensor_msgs::ImageConstPtr& msg);
+
+        /* FIXME Implement single-shot with object selection */
+        /* For now, single-shot runs on first object for backward compatibility */
+        bool singleShotService(blort_ros::EstimatePose::Request &req,
+                               blort_ros::EstimatePose::Response &resp);
+    };
+};
+
+#endif // ifndef _H_TRACKER_NODE_H_
+

--- a/blort_ros/src/nodes/tracker_node.h
+++ b/blort_ros/src/nodes/tracker_node.h
@@ -114,7 +114,7 @@ public:
 
 private:
 
-    void recovery(size_t i, blort_ros::RecoveryCall srv);
+    void recovery(blort_ros::RecoveryCall srv);
 
     // STATE DESIGN PATTERN
     // to implement the different tracker modes
@@ -123,7 +123,7 @@ private:
     {
     public:
         virtual void reconf_callback(blort_ros::TrackerConfig &config, uint32_t level) = 0;
-        virtual blort_ros::RecoveryCall getRecoveryCall(size_t i, const sensor_msgs::ImageConstPtr& msg) = 0;
+        virtual blort_ros::RecoveryCall getRecoveryCall(std::vector<size_t> & i, const sensor_msgs::ImageConstPtr& msg) = 0;
     };
 
     class TrackingMode : public Mode
@@ -138,7 +138,7 @@ private:
 
         virtual void reconf_callback(blort_ros::TrackerConfig &config, uint32_t level);
 
-        virtual blort_ros::RecoveryCall getRecoveryCall(size_t i, const sensor_msgs::ImageConstPtr& msg);
+        virtual blort_ros::RecoveryCall getRecoveryCall(std::vector<size_t> & i, const sensor_msgs::ImageConstPtr& msg);
 
         // The real initialization is being done after receiving the camerainfo.
         void cam_info_callback(const sensor_msgs::CameraInfo &msg);
@@ -167,7 +167,7 @@ private:
 
         virtual void reconf_callback(blort_ros::TrackerConfig &config, uint32_t level);
 
-        virtual blort_ros::RecoveryCall getRecoveryCall(size_t i, const sensor_msgs::ImageConstPtr& msg);
+        virtual blort_ros::RecoveryCall getRecoveryCall(std::vector<size_t> & i, const sensor_msgs::ImageConstPtr& msg);
 
         /* FIXME Implement single-shot with object selection */
         /* For now, single-shot runs on first object for backward compatibility */

--- a/blort_ros/src/trackerinterface.hpp
+++ b/blort_ros/src/trackerinterface.hpp
@@ -65,15 +65,13 @@ namespace blort_ros
     class TrackerInterface
     {
     protected:
-        tracker_mode current_mode;
-        tracker_confidence current_conf;
+        std::vector<tracker_mode> current_modes;
+        std::vector<tracker_confidence> current_confs;
         cv::Mat last_image;
 
     public:
         TrackerInterface()
         {
-            current_mode = TRACKER_RECOVERY_MODE;
-            current_conf = TRACKER_CONF_LOST;
         }
         virtual void track() = 0;
         virtual void recovery() = 0;
@@ -93,11 +91,11 @@ namespace blort_ros
                 break;
             }
         }
-        virtual void switchToTracking(){ current_conf = TRACKER_CONF_FAIR; current_mode = TRACKER_TRACKING_MODE; }
-        virtual void switchToRecovery(){ current_conf = TRACKER_CONF_LOST; current_mode = TRACKER_RECOVERY_MODE; }
-        virtual void reset(){ switchToRecovery(); }
-        tracker_mode getMode(){ return current_mode; }
-        tracker_confidence getConfidence(){ return current_conf; }
+        virtual void switchToTracking(size_t id){ current_confs[id] = TRACKER_CONF_FAIR; current_modes[id] = TRACKER_TRACKING_MODE; }
+        virtual void switchToRecovery(size_t id){ current_confs[id] = TRACKER_CONF_LOST; current_modes[id] = TRACKER_RECOVERY_MODE; }
+        virtual void reset(size_t id){ switchToRecovery(id); }
+        tracker_mode getMode(size_t id){ return current_modes[id]; }
+        tracker_confidence getConfidence(size_t id){ return current_confs[id]; }
     };
 }
 

--- a/blort_ros/src/trackerinterface.hpp
+++ b/blort_ros/src/trackerinterface.hpp
@@ -77,7 +77,17 @@ namespace blort_ros
         virtual void recovery() = 0;
         void process(cv::Mat img)
         {
-            last_image       = img;            
+            last_image = img;
+            tracker_mode current_mode = TRACKER_RECOVERY_MODE;
+            for(size_t i = 0; current_modes.size(); ++i)
+            {
+                if(current_modes[i] > current_mode)
+                {
+                    //FIXME tracking and locked mode are equivalent for now
+                    current_mode = current_modes[i];
+                    break;
+                }
+            }
             switch(current_mode)
             {
             case TRACKER_RECOVERY_MODE:
@@ -94,8 +104,8 @@ namespace blort_ros
         virtual void switchToTracking(size_t id){ current_confs[id] = TRACKER_CONF_FAIR; current_modes[id] = TRACKER_TRACKING_MODE; }
         virtual void switchToRecovery(size_t id){ current_confs[id] = TRACKER_CONF_LOST; current_modes[id] = TRACKER_RECOVERY_MODE; }
         virtual void reset(size_t id){ switchToRecovery(id); }
-        tracker_mode getMode(size_t id){ return current_modes[id]; }
-        tracker_confidence getConfidence(size_t id){ return current_confs[id]; }
+        const std::vector<tracker_mode> & getModes(){ return current_modes; }
+        const std::vector<tracker_confidence> & getConfidence(){ return current_confs; }
     };
 }
 

--- a/blort_ros/srv/RecoveryCall.srv
+++ b/blort_ros/srv/RecoveryCall.srv
@@ -1,5 +1,6 @@
-std_msgs/UInt32 object_id
+std_msgs/UInt32[] object_ids
 sensor_msgs/Image Image
 ---
-std_msgs/UInt32 object_id
-geometry_msgs/Pose Pose
+std_msgs/UInt32[] object_ids
+bool[] object_founds
+geometry_msgs/Pose[] Poses

--- a/blort_ros/srv/RecoveryCall.srv
+++ b/blort_ros/srv/RecoveryCall.srv
@@ -1,3 +1,5 @@
+std_msgs/UInt32 object_id
 sensor_msgs/Image Image
 ---
+std_msgs/UInt32 object_id
 geometry_msgs/Pose Pose

--- a/blort_ros/srv/TrackerCommand.srv
+++ b/blort_ros/srv/TrackerCommand.srv
@@ -11,6 +11,7 @@
 # 5 --> show color image
 # 6 --> toggle edges image flag
 # 7 --> print statistics
+# 8 --> switch tracking on/off
 #
 uint8 code
 uint8[] param

--- a/blort_ros/srv/TrackerCommand.srv
+++ b/blort_ros/srv/TrackerCommand.srv
@@ -13,5 +13,5 @@
 # 7 --> print statistics
 #
 uint8 code
-uint8 param
+uint8[] param
 ---


### PR DESCRIPTION
Hi,

This pull request implements multiple objects recognition with a single instance of a recognition/tracking nodes pair. It tries to share as much computation between objects as possible in order to maintain good performance. However, on lower end systems, the detector node can slow up the tracking node significantly.

It is also possible (through service calls) to enable/disable tracking for certain objects. However, right now it is not possible to:
- train multiple objects at the same time (that wouldn't be very useful anyway I think)
- add objects on the fly and/or give an initial set of objects to track, all objects that you wish to track should be present in the configuration file at the beginning and they will all be tracked by default. Both of these options may be interesting to add later on.
- single-shot mode only works with one object

Best regards,
