### PR TITLE
Fix cppcheck warning-to-error

### DIFF
--- a/blort/src/Recognizer3D/Recognizer3D.cpp
+++ b/blort/src/Recognizer3D/Recognizer3D.cpp
@@ -224,7 +224,7 @@ bool Recognizer3D::recognize(IplImage* tFrame, std::map<std::string, boost::shar
   {
     bool detectResult = false;
     // if there are objects selected, handle only those, if not, look for all
-    if(select.count(m_sift_models[i]->file_name) && select.at(m_sift_models[i]->file_name) || select.empty()) // ABSOLUTE FILENAME FULLPATH
+    if((select.count(m_sift_models[i]->file_name) && select.at(m_sift_models[i]->file_name)) || select.empty()) // ABSOLUTE FILENAME FULLPATH
     {
       ROS_ERROR_STREAM("Recognizer3D::recognize: filename: " << m_sift_models[i]->file_name);
       detectResult = m_detect.Detect(m_image_keys, *m_sift_models[i]);


### PR DESCRIPTION
This fixes (and hopefully maintains the behaviour):
/home/sampfeiffer/svn/catkin_ws/src/perception_blort/blort/src/Recognizer3D/Recognizer3D.cpp: In member function ‘bool blortRecognizer::Recognizer3D::recognize(IplImage*, std::mapstd::basic_string<char, boost::shared_ptrTomGine::tgPose >&, std::mapstd::basic_string<char, double>&, const std::mapstd::basic_string<char, bool>&)’:
/home/sampfeiffer/svn/catkin_ws/src/perception_blort/blort/src/Recognizer3D/Recognizer3D.cpp:227:108: error: suggest parentheses around ‘&&’ within ‘||’ [-Werror=parentheses]
cc1plus: some warnings being treated as errors
Command exited with non-zero status 1
Recognizer3D.cpp build time cppcheck(2.47)  g++(3.31)
