### PR TITLE
Increase detection rate of singleshot mode

### DIFF
--- a/blort_ros/src/nodes/tracker_node.cpp
+++ b/blort_ros/src/nodes/tracker_node.cpp
@@ -326,7 +326,7 @@ bool TrackerNode::SingleShotMode::singleShotService(blort_msgs::EstimatePose::Re
     parent_->tracker->enableAllTracking(false);
     parent_->tracker->setTracked("Pringles", true);
 
-    parent_->tracker->setPublishMode(blort_ros::TRACKER_PUBLISH_GOOD);
+    parent_->tracker->setPublishMode(blort_ros::TRACKER_PUBLISH_GOOD_AND_FAIR);
     parent_->tracker->setVisualizeObjPose(true);
     blort_msgs::SetCameraInfo camera_info;
     camera_info.request.CameraInfo = *lastCameraInfo;


### PR DESCRIPTION
Accept lower quality tracking states to increase detection rate of this mode. Using the edgeConf threshold is usually enough to determine if the object is properly detected and tracked.
