### PR TITLE
Accept GOOD and FAIR tracking quality states

### DIFF
--- a/blort_ros/src/nodes/tracker_node.cpp
+++ b/blort_ros/src/nodes/tracker_node.cpp
@@ -438,7 +438,7 @@ void TrackerNode::SingleShotMode::goalCb(AcServer::GoalHandle gh)
                   << ss.str() <<"' in " << goal->refine_pose_time << "seconds.");
 
 
-  parent_->tracker->setPublishMode(blort_ros::TRACKER_PUBLISH_GOOD);
+  parent_->tracker->setPublishMode(blort_ros::TRACKER_PUBLISH_GOOD_AND_FAIR);
   parent_->tracker->setVisualizeObjPose(true);
   blort_msgs::SetCameraInfo camera_info;
   camera_info.request.CameraInfo = *lastCameraInfo;


### PR DESCRIPTION
Accept lower quality tracking states to increase detection rate of the single-shot action. Using the edgeConf threshold is usually enough to determine if the object is properly detected and tracked.
